### PR TITLE
feat: add reduced-domain mirror symmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - CPU-capable for **fast prototyping**, even on your laptop.
 - Intuitive and **familiar API**.
 - Native **FDFD mode solver** with discrete Yee-grid refinement and validation.
-- **CPML**, absorbing layers and PEC boundaries.
+- **CPML**, absorbing layers, PEC/PMC boundaries, and mirror-symmetry reduction.
 - Unidirectional **mode sources** (single freq. and broadband, Huygens fields + TFSF, TE/TM).
 - **Gaussian sources**, e.g. for grating coupler simulations.
 - Integrated **rasterization module**.

--- a/beamz/__init__.py
+++ b/beamz/__init__.py
@@ -43,7 +43,7 @@ from beamz.design.structures import (
     Sphere,
     Taper,
 )
-from beamz.devices.boundaries import PEC, PML, Absorber
+from beamz.devices.boundaries import PEC, PMC, PML, Absorber
 from beamz.devices.monitors import FieldMonitor, FieldRecorder, FluxMonitor, ModeMonitor
 from beamz.devices.ports import Port
 from beamz.devices.sources import (
@@ -125,6 +125,7 @@ __all__ = [
     "RunTermination",
     "PML",
     "PEC",
+    "PMC",
     "Absorber",
     "display_status",
     "create_plain_progress",

--- a/beamz/devices/__init__.py
+++ b/beamz/devices/__init__.py
@@ -1,5 +1,5 @@
 """Immutable sources, monitors, ports, and boundary specifications."""
 
-from beamz.devices.boundaries import PEC, PML, Absorber
+from beamz.devices.boundaries import PEC, PMC, PML, Absorber
 
-__all__ = ["Absorber", "PEC", "PML"]
+__all__ = ["Absorber", "PEC", "PMC", "PML"]

--- a/beamz/devices/_boundary_compile.py
+++ b/beamz/devices/_boundary_compile.py
@@ -14,6 +14,7 @@ from beamz.const import EPS_0, MU_0
 from beamz.design.discretization import MaterialGrid
 from beamz.devices.boundaries import (
     PEC,
+    PMC,
     PML,
     Absorber,
     edges_for_dimension,
@@ -71,6 +72,7 @@ class BoundaryData:
     profiles: Mapping[str, Any] | None
     masks: Mapping[str, Any]
     metallic_edges: frozenset[str]
+    pmc_edges: frozenset[str]
 
 
 class _ComponentSupport:
@@ -113,6 +115,18 @@ def resolve_metallic_edges(boundaries, is_3d: bool) -> frozenset[str]:
         else:
             metallic.difference_update(edges)
     return frozenset(metallic)
+
+
+def resolve_pmc_edges(boundaries, is_3d: bool) -> frozenset[str]:
+    """Apply boundary precedence and return faces using PMC-like parity."""
+    pmc: set[str] = set()
+    for boundary in normalize_boundaries(boundaries):
+        edges = edges_for_dimension(boundary.edges, bool(is_3d))
+        if isinstance(boundary, PMC):
+            pmc.update(edges)
+        else:
+            pmc.difference_update(edges)
+    return frozenset(pmc)
 
 
 def compile_metallic_masks(
@@ -870,4 +884,5 @@ def lower_boundaries(
             polarization_2d=polarization_2d,
         ),
         resolve_metallic_edges(boundaries, len(material_grid.shape) == 3),
+        resolve_pmc_edges(boundaries, len(material_grid.shape) == 3),
     )

--- a/beamz/devices/boundaries.py
+++ b/beamz/devices/boundaries.py
@@ -94,6 +94,42 @@ class PEC:
 
 
 @dataclass(frozen=True, slots=True)
+class PMC:
+    """Request perfect-magnetic-conductor behavior on domain edges.
+
+    PMC is primarily useful as the even-parity counterpart of a PEC-like mirror
+    plane. It enforces the corresponding vector-field reflection parity at the
+    selected domain faces.
+    """
+
+    edges: BoundaryEdges = "all"
+    thickness: float = 0.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "edges", normalize_edges(self.edges))
+        object.__setattr__(self, "thickness", 0.0)
+
+    def updated_copy(self, **changes):
+        """Return a validated boundary with selected fields replaced.
+
+        Parameters
+        ----------
+        **changes : object
+            Dataclass fields to replace.
+
+        Returns
+        -------
+        PMC
+            New immutable boundary specification.
+        """
+        return replace(self, **changes)
+
+    def _get_edges_for_dimensionality(self, is_3d):
+        """Compatibility adapter for low-level callers."""
+        return list(edges_for_dimension(self.edges, bool(is_3d)))
+
+
+@dataclass(frozen=True, slots=True)
 class PML:
     """Request a graded absorbing layer on selected domain edges.
 
@@ -263,17 +299,17 @@ class Absorber:
         return list(edges_for_dimension(self.edges, bool(is_3d)))
 
 
-Boundary = PEC | PML | Absorber
+Boundary = PEC | PMC | PML | Absorber
 
 
 def normalize_boundaries(boundaries) -> tuple[Boundary, ...]:
     """Freeze boundary input and preserve Beamz's historical all-PEC default."""
     resolved = tuple(boundaries) if boundaries else (PEC(),)
-    if not all(isinstance(boundary, (PEC, PML, Absorber)) for boundary in resolved):
+    if not all(isinstance(boundary, (PEC, PMC, PML, Absorber)) for boundary in resolved):
         raise TypeError(
-            "boundaries must contain only PEC, PML, or Absorber specifications"
+            "boundaries must contain only PEC, PMC, PML, or Absorber specifications"
         )
     return resolved
 
 
-__all__ = ["Absorber", "Boundary", "PEC", "PML"]
+__all__ = ["Absorber", "Boundary", "PEC", "PMC", "PML"]

--- a/beamz/lattice.py
+++ b/beamz/lattice.py
@@ -521,7 +521,12 @@ def metric_adjacent_difference(array, axis, inverse_distance):
 
 
 def _pad_with_boundary_ghosts(
-    array, axis, metallic_edges, *, logical_size: int | None = None
+    array,
+    axis,
+    metallic_edges,
+    pmc_edges=frozenset(),
+    *,
+    logical_size: int | None = None,
 ):
     logical_size = int(array.shape[axis]) if logical_size is None else int(logical_size)
     if logical_size <= 0 or logical_size > int(array.shape[axis]):
@@ -540,19 +545,33 @@ def _pad_with_boundary_ghosts(
     low_edge, high_edge = (("front", "back"), ("bottom", "top"), ("left", "right"))[
         axis
     ]
+    low_sample = jnp.take(physical, jnp.array([0]), axis)
+    high_sample = jnp.take(physical, jnp.array([logical_size - 1]), axis)
     low = (
-        zero if low_edge in metallic_edges else jnp.take(physical, jnp.array([0]), axis)
+        zero
+        if low_edge in metallic_edges
+        else -low_sample
+        if low_edge in pmc_edges
+        else low_sample
     )
     high = (
         zero
         if high_edge in metallic_edges
-        else jnp.take(physical, jnp.array([logical_size - 1]), axis)
+        else -high_sample
+        if high_edge in pmc_edges
+        else high_sample
     )
     return jnp.concatenate((low, physical, high, storage_padding), axis=axis)
 
 
 def build_h_boundary_views_for_e_3d(
-    hx, hy, hz, metallic_edges=frozenset(), *, logical_shapes=None
+    hx,
+    hy,
+    hz,
+    metallic_edges=frozenset(),
+    pmc_edges=frozenset(),
+    *,
+    logical_shapes=None,
 ):
     """Create the six ghost-padded H views consumed by the 3D E curl."""
     return {
@@ -560,6 +579,7 @@ def build_h_boundary_views_for_e_3d(
             field,
             axis,
             metallic_edges,
+            pmc_edges,
             logical_size=(
                 None if logical_shapes is None else logical_shapes[component][axis]
             ),

--- a/beamz/simulation/README.md
+++ b/beamz/simulation/README.md
@@ -26,11 +26,17 @@ The supported `beamz.simulation` surface is intentionally small:
 - `Simulation`, `SimulationState`, `SimulationRun`, `SimulationResults`, `MonitorResults`
 - `AutoTermination`, `RunTermination`
 - `GridSpec`, `GaussianPulse`, `ModeSpec`
-- `Absorber`, `PML`, `PEC`, `Port`
+- `Absorber`, `PML`, `PEC`, `PMC`, `Port`
 
 Numerical Yee helpers, mutable mesh builders, source/monitor lowering, update
 kernels, and compiled plan types remain private implementation details rather
 than forming a second public solver API.
+
+Mirror-symmetric problems can use `Simulation(symmetry=(sx, sy, sz))`, where
+each physical-axis entry is `0` (disabled), `1` (even electric-field parity), or
+`-1` (odd electric-field parity). See the
+[mirror-symmetry guide](../../docs/mirror-symmetry.md) for the workflow and
+validation rules.
 
 ## Choosing an execution method
 

--- a/beamz/simulation/__init__.py
+++ b/beamz/simulation/__init__.py
@@ -1,7 +1,7 @@
 """Simulation module for BEAMZ."""
 
 from beamz.design.grid_spec import GridSpec
-from beamz.devices.boundaries import PEC, PML, Absorber
+from beamz.devices.boundaries import PEC, PMC, PML, Absorber
 from beamz.devices.modes.specs import ModeSpec
 from beamz.devices.ports import Port
 from beamz.devices.sources.time import GaussianPulse
@@ -33,5 +33,6 @@ __all__ = [
     "inf",
     "PML",
     "PEC",
+    "PMC",
     "Absorber",
 ]

--- a/beamz/simulation/api.py
+++ b/beamz/simulation/api.py
@@ -182,6 +182,25 @@ def _normalize_plane_2d(plane) -> str:
     return plane
 
 
+def _normalize_symmetry(symmetry, *, is_3d: bool, plane_2d: str) -> tuple[int, int, int]:
+    """Validate physical-axis reflection parity for one simulation domain."""
+    try:
+        values = tuple(int(value) for value in symmetry)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Simulation symmetry must contain exactly three values in {-1, 0, 1}.") from exc
+    if len(values) != 3 or any(value not in {-1, 0, 1} for value in values):
+        raise ValueError("Simulation symmetry must contain exactly three values in {-1, 0, 1}.")
+    if not is_3d:
+        inactive = ({"x", "y", "z"} - set(plane_2d)).pop()
+        inactive_index = {"x": 0, "y": 1, "z": 2}[inactive]
+        if values[inactive_index] != 0:
+            raise ValueError(
+                f"Simulation symmetry along inactive {inactive}-axis must be 0 "
+                f"for a {plane_2d!r} 2D simulation."
+            )
+    return values  # type: ignore[return-value]
+
+
 def _time_from_run_time(time, run_time, grid_spec, resolution, dims):
     # Preserve an explicit time grid; otherwise derive a stable step and include the endpoint.
     if time is not None or run_time is None:
@@ -548,6 +567,10 @@ class Simulation:
     normalize_source : int or None, default=0
         Source index used to normalize frequency-domain monitor data. Use ``None``
         to retain raw acquisitions.
+    symmetry : tuple of {-1, 0, 1}, default=(0, 0, 0)
+        Reflection parity across the domain-center planes normal to physical x, y,
+        and z. ``0`` disables reduction, ``1`` selects even (PMC-like) parity,
+        and ``-1`` selects odd (PEC-like) parity.
     raster_options : RasterOptions, optional
         Native raster quality and smoothing policy. Component selection remains
         automatic for the simulation dimensionality. Simulations default to
@@ -606,6 +629,7 @@ class Simulation:
     setup_device_policy: str
     setup_device_resolved: str
     normalize_source: int | None
+    symmetry: tuple[int, int, int]
     raster_options: Any
     coordinate_offset: tuple[float, float, float]
     _uses_realized_grid: bool
@@ -631,6 +655,7 @@ class Simulation:
         run_time: float | None = None,
         setup_device: Literal["auto", "cpu", "default"] | None = None,
         normalize_source: int | None = 0,
+        symmetry: tuple[Literal[-1, 0, 1], Literal[-1, 0, 1], Literal[-1, 0, 1]] = (0, 0, 0),
         raster_options=None,
     ):
         polarization = normalize_polarization_2d(polarization)
@@ -707,6 +732,7 @@ class Simulation:
         # 3. Canonicalize devices, time, plane, and boundaries before resolving the setup
         # device; subsequent cache identity depends on these normalized values.
         is_3d = _design_is_3d(design)
+        symmetry = _normalize_symmetry(symmetry, is_3d=is_3d, plane_2d=plane_2d)
         if is_3d and polarization != "tm":
             raise ValueError("polarization applies only to 2D simulations.")
         if (
@@ -758,6 +784,7 @@ class Simulation:
         object.__setattr__(self, "setup_device_policy", setup_device_policy)
         object.__setattr__(self, "setup_device_resolved", setup_device_resolved)
         object.__setattr__(self, "normalize_source", normalize_source)
+        object.__setattr__(self, "symmetry", symmetry)
         object.__setattr__(self, "raster_options", raster_options)
         object.__setattr__(self, "coordinate_offset", tuple(float(v) for v in offset))
         object.__setattr__(self, "_uses_realized_grid", uses_realized_grid)
@@ -846,6 +873,7 @@ class Simulation:
             self.run_time,
             self.setup_device_policy,
             self.normalize_source,
+            self.symmetry,
             self.raster_options,
         )
 
@@ -907,6 +935,7 @@ class Simulation:
             "run_time",
             "setup_device",
             "normalize_source",
+            "symmetry",
             "raster_options",
         }
         unknown = set(changes) - allowed
@@ -939,6 +968,7 @@ class Simulation:
             "run_time": self.run_time,
             "setup_device": self.setup_device_policy,
             "normalize_source": self.normalize_source,
+            "symmetry": self.symmetry,
             "raster_options": self.raster_options,
         }
         values.update(changes)
@@ -1182,7 +1212,8 @@ class Simulation:
                 bool(self.is_3d),
                 str(self.plane_2d),
                 self.coordinate_offset,
-                self.polarization,
+                polarization_2d=self.polarization,
+                symmetry=self.symmetry,
             ),
             material_grid,
             tuple(self.sources),

--- a/beamz/simulation/api.py
+++ b/beamz/simulation/api.py
@@ -1193,6 +1193,25 @@ class Simulation:
         """
         # 1. Resolve Design's material raster; numerical boundary lowering belongs to compile.py.
         material_grid = self._material_grid(progress=progress)
+        boundaries = self.boundaries
+        if any(self.symmetry):
+            from beamz.simulation.symmetry import (
+                reduce_material_grid,
+                symmetry_boundaries,
+            )
+
+            material_grid = reduce_material_grid(
+                material_grid,
+                self.symmetry,
+                is_3d=self.is_3d,
+                plane_2d=self.plane_2d,
+            )
+            boundaries = symmetry_boundaries(
+                boundaries,
+                self.symmetry,
+                is_3d=self.is_3d,
+                plane_2d=self.plane_2d,
+            )
         requested_steps = int(self.num_steps if num_steps is None else num_steps)
         # 2. Snapshot grid, run, and domain controls into immutable value objects, then
         # attach normalized sources, monitors, boundaries, and sharding configuration.
@@ -1218,7 +1237,7 @@ class Simulation:
             material_grid,
             tuple(self.sources),
             tuple(self.monitors),
-            tuple(self.boundaries),
+            tuple(boundaries),
             compiler_sharding,
         )
 

--- a/beamz/simulation/api.py
+++ b/beamz/simulation/api.py
@@ -182,14 +182,31 @@ def _normalize_plane_2d(plane) -> str:
     return plane
 
 
-def _normalize_symmetry(symmetry, *, is_3d: bool, plane_2d: str) -> tuple[int, int, int]:
+def _normalize_symmetry(
+    symmetry, *, is_3d: bool, plane_2d: str
+) -> tuple[int, int, int]:
     """Validate physical-axis reflection parity for one simulation domain."""
     try:
-        values = tuple(int(value) for value in symmetry)
+        raw_values = tuple(symmetry)
     except (TypeError, ValueError) as exc:
-        raise ValueError("Simulation symmetry must contain exactly three values in {-1, 0, 1}.") from exc
-    if len(values) != 3 or any(value not in {-1, 0, 1} for value in values):
-        raise ValueError("Simulation symmetry must contain exactly three values in {-1, 0, 1}.")
+        raise ValueError(
+            "Simulation symmetry must contain exactly three values in {-1, 0, 1}."
+        ) from exc
+    try:
+        valid = len(raw_values) == 3 and all(
+            not isinstance(value, (bool, np.bool_))
+            and np.isfinite(value)
+            and int(value) == value
+            and int(value) in {-1, 0, 1}
+            for value in raw_values
+        )
+    except (TypeError, ValueError, OverflowError):
+        valid = False
+    if not valid:
+        raise ValueError(
+            "Simulation symmetry must contain exactly three values in {-1, 0, 1}."
+        )
+    values = tuple(int(value) for value in raw_values)
     if not is_3d:
         inactive = ({"x", "y", "z"} - set(plane_2d)).pop()
         inactive_index = {"x": 0, "y": 1, "z": 2}[inactive]
@@ -655,7 +672,11 @@ class Simulation:
         run_time: float | None = None,
         setup_device: Literal["auto", "cpu", "default"] | None = None,
         normalize_source: int | None = 0,
-        symmetry: tuple[Literal[-1, 0, 1], Literal[-1, 0, 1], Literal[-1, 0, 1]] = (0, 0, 0),
+        symmetry: tuple[Literal[-1, 0, 1], Literal[-1, 0, 1], Literal[-1, 0, 1]] = (
+            0,
+            0,
+            0,
+        ),
         raster_options=None,
     ):
         polarization = normalize_polarization_2d(polarization)

--- a/beamz/simulation/compile.py
+++ b/beamz/simulation/compile.py
@@ -23,6 +23,7 @@ from beamz.devices._boundary_compile import (
     BoundaryData,
     lower_boundaries,
 )
+from beamz.devices.boundaries import PMC
 from beamz.devices.monitors.compiler import compile_monitor_specs
 from beamz.devices.sources.compiler import compile_source_specs
 from beamz.lattice import (
@@ -864,9 +865,12 @@ def compile_program(
             "CUDA execution currently supports one GPU; use backend='jax' for "
             "multi-device sharding."
         )
-    if requested_backend not in {"auto", "jax"} and any(simulation.symmetry):
+    has_pmc = any(isinstance(boundary, PMC) for boundary in simulation.boundaries)
+    if requested_backend not in {"auto", "jax"} and (
+        any(simulation.symmetry) or has_pmc
+    ):
         raise CudaBackendUnavailable(
-            "CUDA execution does not yet support reduced-domain symmetry; "
+            "CUDA execution does not yet support PMC or reduced-domain symmetry; "
             "use backend='jax'."
         )
     cuda_problem_supported = (
@@ -874,6 +878,7 @@ def compile_program(
         and cuda_material_supported
         and cuda_sharding_supported
         and not any(simulation.symmetry)
+        and not has_pmc
     )
     resolved_backend = (
         "jax"

--- a/beamz/simulation/compile.py
+++ b/beamz/simulation/compile.py
@@ -70,6 +70,7 @@ class CompiledProgramKey:
     is_3d: bool
     plane_2d: str
     polarization_2d: str
+    symmetry: tuple[int, int, int]
     loop_kind: str
     source_single_slab_dense: bool
     backend: str
@@ -91,6 +92,7 @@ class CompiledProgramKey:
             request.domain.is_3d,
             request.domain.plane_2d,
             request.domain.polarization_2d,
+            request.domain.symmetry,
             request.run.loop_kind,
             request.run.source_single_slab_dense,
             request.run.backend,
@@ -524,6 +526,7 @@ def _compile_boundary(fields, cpml, boundary_data, *, is_3d: bool) -> BoundaryPl
     masks = fields.metallic_masks
     return BoundaryPlan(
         metallic_edges_2d=(frozenset() if is_3d else boundary_data.metallic_edges),
+        pmc_edges=boundary_data.pmc_edges,
         cpml=cpml,
         metallic=MetallicPlan(
             masks["Ex"],
@@ -544,7 +547,7 @@ def compile_simulation(request: SimulationRequest) -> CompiledProgram:
         request.materials,
         component_shapes(request.materials.shape, request.domain.polarization_2d),
         request.boundaries,
-        request.domain.size,
+        request.materials.grid.extent,
         request.run.dt,
         polarization_2d=request.domain.polarization_2d,
     )
@@ -861,8 +864,16 @@ def compile_program(
             "CUDA execution currently supports one GPU; use backend='jax' for "
             "multi-device sharding."
         )
+    if requested_backend not in {"auto", "jax"} and any(simulation.symmetry):
+        raise CudaBackendUnavailable(
+            "CUDA execution does not yet support reduced-domain symmetry; "
+            "use backend='jax'."
+        )
     cuda_problem_supported = (
-        cuda_grid_supported and cuda_material_supported and cuda_sharding_supported
+        cuda_grid_supported
+        and cuda_material_supported
+        and cuda_sharding_supported
+        and not any(simulation.symmetry)
     )
     resolved_backend = (
         "jax"

--- a/beamz/simulation/kernels.py
+++ b/beamz/simulation/kernels.py
@@ -563,6 +563,7 @@ def cpml_update_e_from_h_3d(
     terms,
     psi_terms,
     metallic_edges,
+    pmc_edges=frozenset(),
     dt,
     conductivities,
     inverse_permittivities,
@@ -572,7 +573,7 @@ def cpml_update_e_from_h_3d(
 ):
     """Advance 3D E fields and their six packed CPML memories."""
     views = build_h_boundary_views_for_e_3d(
-        hx, hy, hz, metallic_edges, logical_shapes=logical_shapes
+        hx, hy, hz, metallic_edges, pmc_edges, logical_shapes=logical_shapes
     )
     derivatives = (
         ("hz_y", 1, ex.shape),
@@ -638,6 +639,7 @@ def cpml_update_e_from_h_3d_metric(
     terms,
     psi_terms,
     metallic_edges,
+    pmc_edges=frozenset(),
     dt,
     conductivities,
     inverse_permittivities,
@@ -647,7 +649,7 @@ def cpml_update_e_from_h_3d_metric(
 ):
     """Advance 3D E/CPML using physical center-to-center distances."""
     views = build_h_boundary_views_for_e_3d(
-        hx, hy, hz, metallic_edges, logical_shapes=logical_shapes
+        hx, hy, hz, metallic_edges, pmc_edges, logical_shapes=logical_shapes
     )
     derivatives = (
         ("hz_y", 1, metrics.h_to_e_y, ex.shape),
@@ -738,7 +740,9 @@ def tm_xy_curl_e_to_h_2d(ez, resolution, hx_shape, hy_shape, metallic_edges):
     )
 
 
-def _tm_xy_h_derivatives(hx, hy, resolution, metallic_edges):
+def _tm_xy_h_derivatives(
+    hx, hy, resolution, metallic_edges, pmc_edges=frozenset()
+):
     """Return padded H derivatives on the complete Ez node lattice."""
     resolution = _scalar_like(resolution, hy.dtype)
     left, right = hy[:, :1], hy[:, -1:]
@@ -751,6 +755,14 @@ def _tm_xy_h_derivatives(hx, hy, resolution, metallic_edges):
         bottom = jnp.zeros_like(bottom)
     if "top" in metallic_edges:
         top = jnp.zeros_like(top)
+    if "left" in pmc_edges:
+        left = -left
+    if "right" in pmc_edges:
+        right = -right
+    if "bottom" in pmc_edges:
+        bottom = -bottom
+    if "top" in pmc_edges:
+        top = -top
     padded_hy = jnp.concatenate((left, hy, right), axis=1)
     padded_hx = jnp.concatenate((bottom, hx, top), axis=0)
     d_hy_dx = (padded_hy[:, 1:] - padded_hy[:, :-1]) / resolution
@@ -758,9 +770,18 @@ def _tm_xy_h_derivatives(hx, hy, resolution, metallic_edges):
     return d_hy_dx, d_hx_dy
 
 
-def tm_xy_curl_h_to_e_2d(hx, hy, resolution, ez_shape, metallic_edges=frozenset()):
+def tm_xy_curl_h_to_e_2d(
+    hx,
+    hy,
+    resolution,
+    ez_shape,
+    metallic_edges=frozenset(),
+    pmc_edges=frozenset(),
+):
     """Differentiate Hx and Hy onto the native Ez support."""
-    d_hy_dx, d_hx_dy = _tm_xy_h_derivatives(hx, hy, resolution, metallic_edges)
+    d_hy_dx, d_hx_dy = _tm_xy_h_derivatives(
+        hx, hy, resolution, metallic_edges, pmc_edges
+    )
     curl = d_hy_dx - d_hx_dy
     if curl.shape != ez_shape:
         raise ValueError(f"curl(H) shape {curl.shape} does not match Ez {ez_shape}")
@@ -793,12 +814,15 @@ def tm_xy_cpml_curl_h_to_e_2d(
     resolution,
     ez_shape,
     metallic_edges,
+    pmc_edges=frozenset(),
     *,
     terms,
     psi_e_terms,
 ):
     """Correct the two H derivatives with canonical 2D CPML memory."""
-    derivatives = _tm_xy_h_derivatives(hx, hy, resolution, metallic_edges)
+    derivatives = _tm_xy_h_derivatives(
+        hx, hy, resolution, metallic_edges, pmc_edges
+    )
     corrected = tuple(
         correct_cpml_term(derivative, psi, term)
         for derivative, psi, term in zip(derivatives, psi_e_terms, terms, strict=True)
@@ -820,7 +844,7 @@ def te_xy_curl_e_to_h_2d(ex, ey, resolution, hz_shape):
     return curl
 
 
-def _te_xy_h_derivatives(hz, resolution, metallic_edges):
+def _te_xy_h_derivatives(hz, resolution, metallic_edges, pmc_edges=frozenset()):
     """Return padded Hz derivatives on the complete Ex and Ey supports."""
     resolution = _scalar_like(resolution, hz.dtype)
     bottom, top = hz[:1, :], hz[-1:, :]
@@ -833,6 +857,14 @@ def _te_xy_h_derivatives(hz, resolution, metallic_edges):
         left = jnp.zeros_like(left)
     if "right" in metallic_edges:
         right = jnp.zeros_like(right)
+    if "bottom" in pmc_edges:
+        bottom = -bottom
+    if "top" in pmc_edges:
+        top = -top
+    if "left" in pmc_edges:
+        left = -left
+    if "right" in pmc_edges:
+        right = -right
     padded_y = jnp.concatenate((bottom, hz, top), axis=0)
     padded_x = jnp.concatenate((left, hz, right), axis=1)
     return (
@@ -841,9 +873,18 @@ def _te_xy_h_derivatives(hz, resolution, metallic_edges):
     )
 
 
-def te_xy_curl_h_to_e_2d(hz, resolution, ex_shape, ey_shape, metallic_edges):
+def te_xy_curl_h_to_e_2d(
+    hz,
+    resolution,
+    ex_shape,
+    ey_shape,
+    metallic_edges,
+    pmc_edges=frozenset(),
+):
     """Differentiate Hz onto the canonical Ex and Ey supports."""
-    d_hz_dy, d_hz_dx = _te_xy_h_derivatives(hz, resolution, metallic_edges)
+    d_hz_dy, d_hz_dx = _te_xy_h_derivatives(
+        hz, resolution, metallic_edges, pmc_edges
+    )
     curls = d_hz_dy, -d_hz_dx
     if curls[0].shape != ex_shape or curls[1].shape != ey_shape:
         raise ValueError(
@@ -867,9 +908,17 @@ def te_xy_cpml_curl_e_to_h_2d(ex, ey, resolution, *, terms, psi_h_terms):
     return corrected[0][0] + corrected[1][0], tuple(item[1] for item in corrected)
 
 
-def te_xy_cpml_curl_h_to_e_2d(hz, resolution, metallic_edges, *, terms, psi_e_terms):
+def te_xy_cpml_curl_h_to_e_2d(
+    hz,
+    resolution,
+    metallic_edges,
+    pmc_edges=frozenset(),
+    *,
+    terms,
+    psi_e_terms,
+):
     """Correct the Hz derivatives used by the Ex and Ey updates."""
-    derivatives = _te_xy_h_derivatives(hz, resolution, metallic_edges)
+    derivatives = _te_xy_h_derivatives(hz, resolution, metallic_edges, pmc_edges)
     corrected = tuple(
         correct_cpml_term(derivative, psi, term)
         for derivative, psi, term in zip(derivatives, psi_e_terms, terms, strict=True)
@@ -885,7 +934,9 @@ def tm_xy_curl_e_to_h_2d_metric(ez, metrics):
     )
 
 
-def _tm_xy_h_derivatives_metric(hx, hy, metrics, metallic_edges):
+def _tm_xy_h_derivatives_metric(
+    hx, hy, metrics, metallic_edges, pmc_edges=frozenset()
+):
     left, right = hy[:, :1], hy[:, -1:]
     bottom, top = hx[:1, :], hx[-1:, :]
     if "left" in metallic_edges:
@@ -896,6 +947,14 @@ def _tm_xy_h_derivatives_metric(hx, hy, metrics, metallic_edges):
         bottom = jnp.zeros_like(bottom)
     if "top" in metallic_edges:
         top = jnp.zeros_like(top)
+    if "left" in pmc_edges:
+        left = -left
+    if "right" in pmc_edges:
+        right = -right
+    if "bottom" in pmc_edges:
+        bottom = -bottom
+    if "top" in pmc_edges:
+        top = -top
     padded_hy = jnp.concatenate((left, hy, right), axis=1)
     padded_hx = jnp.concatenate((bottom, hx, top), axis=0)
     return (
@@ -904,9 +963,13 @@ def _tm_xy_h_derivatives_metric(hx, hy, metrics, metallic_edges):
     )
 
 
-def tm_xy_curl_h_to_e_2d_metric(hx, hy, metrics, ez_shape, metallic_edges):
+def tm_xy_curl_h_to_e_2d_metric(
+    hx, hy, metrics, ez_shape, metallic_edges, pmc_edges=frozenset()
+):
     """Differentiate H onto Ez using physical center-to-center distances."""
-    d_hy_dx, d_hx_dy = _tm_xy_h_derivatives_metric(hx, hy, metrics, metallic_edges)
+    d_hy_dx, d_hx_dy = _tm_xy_h_derivatives_metric(
+        hx, hy, metrics, metallic_edges, pmc_edges
+    )
     curl = d_hy_dx - d_hx_dy
     if curl.shape != ez_shape:
         raise ValueError(f"curl(H) shape {curl.shape} does not match Ez {ez_shape}")
@@ -931,11 +994,14 @@ def tm_xy_cpml_curl_h_to_e_2d_metric(
     metrics,
     ez_shape,
     metallic_edges,
+    pmc_edges=frozenset(),
     *,
     terms,
     psi_e_terms,
 ):
-    derivatives = _tm_xy_h_derivatives_metric(hx, hy, metrics, metallic_edges)
+    derivatives = _tm_xy_h_derivatives_metric(
+        hx, hy, metrics, metallic_edges, pmc_edges
+    )
     corrected = tuple(
         correct_cpml_term(derivative, psi, term)
         for derivative, psi, term in zip(derivatives, psi_e_terms, terms, strict=True)
@@ -957,7 +1023,7 @@ def te_xy_curl_e_to_h_2d_metric(ex, ey, metrics, hz_shape):
     return curl
 
 
-def _te_xy_h_derivatives_metric(hz, metrics, metallic_edges):
+def _te_xy_h_derivatives_metric(hz, metrics, metallic_edges, pmc_edges=frozenset()):
     bottom, top = hz[:1, :], hz[-1:, :]
     left, right = hz[:, :1], hz[:, -1:]
     if "bottom" in metallic_edges:
@@ -968,6 +1034,14 @@ def _te_xy_h_derivatives_metric(hz, metrics, metallic_edges):
         left = jnp.zeros_like(left)
     if "right" in metallic_edges:
         right = jnp.zeros_like(right)
+    if "bottom" in pmc_edges:
+        bottom = -bottom
+    if "top" in pmc_edges:
+        top = -top
+    if "left" in pmc_edges:
+        left = -left
+    if "right" in pmc_edges:
+        right = -right
     padded_y = jnp.concatenate((bottom, hz, top), axis=0)
     padded_x = jnp.concatenate((left, hz, right), axis=1)
     return (
@@ -976,8 +1050,12 @@ def _te_xy_h_derivatives_metric(hz, metrics, metallic_edges):
     )
 
 
-def te_xy_curl_h_to_e_2d_metric(hz, metrics, ex_shape, ey_shape, metallic_edges):
-    d_hz_dy, d_hz_dx = _te_xy_h_derivatives_metric(hz, metrics, metallic_edges)
+def te_xy_curl_h_to_e_2d_metric(
+    hz, metrics, ex_shape, ey_shape, metallic_edges, pmc_edges=frozenset()
+):
+    d_hz_dy, d_hz_dx = _te_xy_h_derivatives_metric(
+        hz, metrics, metallic_edges, pmc_edges
+    )
     curls = d_hz_dy, -d_hz_dx
     if curls[0].shape != ex_shape or curls[1].shape != ey_shape:
         raise ValueError(
@@ -1000,9 +1078,15 @@ def te_xy_cpml_curl_e_to_h_2d_metric(ex, ey, metrics, *, terms, psi_h_terms):
 
 
 def te_xy_cpml_curl_h_to_e_2d_metric(
-    hz, metrics, metallic_edges, *, terms, psi_e_terms
+    hz,
+    metrics,
+    metallic_edges,
+    pmc_edges=frozenset(),
+    *,
+    terms,
+    psi_e_terms,
 ):
-    derivatives = _te_xy_h_derivatives_metric(hz, metrics, metallic_edges)
+    derivatives = _te_xy_h_derivatives_metric(hz, metrics, metallic_edges, pmc_edges)
     corrected = tuple(
         correct_cpml_term(derivative, psi, term)
         for derivative, psi, term in zip(derivatives, psi_e_terms, terms, strict=True)
@@ -1132,6 +1216,7 @@ def update_e_3d_cpml(eng, ctx, coeffs):
         terms=cpml.e_terms,
         psi_terms=eng.cpml_psi_e_terms,
         metallic_edges=cpml.metallic_edges,
+        pmc_edges=ctx.boundary.pmc_edges,
         dt=ctx.dt_scalar,
         conductivities=(
             coeffs.e_conductivity_x,
@@ -1180,6 +1265,7 @@ def update_e_3d_yee(eng, ctx, coeffs):
         eng.hy,
         eng.hz,
         ctx.boundary.cpml.metallic_edges,
+        ctx.boundary.pmc_edges,
         logical_shapes=ctx.boundary.logical_component_shapes,
     )
     ex, ey, ez = fused_update_e_lossy_3d_material(
@@ -1271,6 +1357,7 @@ def update_e_2d_tm_xy(eng, ctx, coeffs):
         ctx.resolution,
         eng.ez.shape,
         ctx.boundary.metallic_edges_2d,
+        ctx.boundary.pmc_edges,
     )
     return _update_e_tm_from_curl(eng, ctx, coeffs, curl_ez)
 
@@ -1284,6 +1371,7 @@ def update_e_2d_tm_xy_cpml(eng, ctx, coeffs):
         ctx.resolution,
         eng.ez.shape,
         ctx.boundary.metallic_edges_2d,
+        ctx.boundary.pmc_edges,
         terms=cpml.e_terms,
         psi_e_terms=eng.cpml_psi_e_terms,
     )
@@ -1340,6 +1428,7 @@ def update_e_2d_te_xy(eng, ctx, coeffs):
         eng.ex.shape,
         eng.ey.shape,
         ctx.boundary.metallic_edges_2d,
+        ctx.boundary.pmc_edges,
     )
     return _update_e_te_from_curls(eng, ctx, coeffs, curls)
 
@@ -1349,6 +1438,7 @@ def update_e_2d_te_xy_cpml(eng, ctx, coeffs):
         eng.hz,
         ctx.resolution,
         ctx.boundary.metallic_edges_2d,
+        ctx.boundary.pmc_edges,
         terms=ctx.boundary.cpml.e_terms,
         psi_e_terms=eng.cpml_psi_e_terms,
     )
@@ -1390,6 +1480,7 @@ def update_e_3d_cpml_metric(eng, ctx, coeffs):
         terms=cpml.e_terms,
         psi_terms=eng.cpml_psi_e_terms,
         metallic_edges=cpml.metallic_edges,
+        pmc_edges=ctx.boundary.pmc_edges,
         dt=ctx.dt_scalar,
         conductivities=(
             coeffs.e_conductivity_x,
@@ -1441,6 +1532,7 @@ def update_e_3d_yee_metric(eng, ctx, coeffs):
         eng.hy,
         eng.hz,
         ctx.boundary.cpml.metallic_edges,
+        ctx.boundary.pmc_edges,
         logical_shapes=ctx.boundary.logical_component_shapes,
     )
     ex, ey, ez = fused_update_e_lossy_3d_material_metric(
@@ -1487,6 +1579,7 @@ def update_e_2d_tm_xy_metric(eng, ctx, coeffs):
         ctx.metrics,
         eng.ez.shape,
         ctx.boundary.metallic_edges_2d,
+        ctx.boundary.pmc_edges,
     )
     return _update_e_tm_from_curl(eng, ctx, coeffs, curl)
 
@@ -1508,6 +1601,7 @@ def update_e_2d_tm_xy_cpml_metric(eng, ctx, coeffs):
         ctx.metrics,
         eng.ez.shape,
         ctx.boundary.metallic_edges_2d,
+        ctx.boundary.pmc_edges,
         terms=ctx.boundary.cpml.e_terms,
         psi_e_terms=eng.cpml_psi_e_terms,
     )
@@ -1526,6 +1620,7 @@ def update_e_2d_te_xy_metric(eng, ctx, coeffs):
         eng.ex.shape,
         eng.ey.shape,
         ctx.boundary.metallic_edges_2d,
+        ctx.boundary.pmc_edges,
     )
     return _update_e_te_from_curls(eng, ctx, coeffs, curls)
 
@@ -1546,6 +1641,7 @@ def update_e_2d_te_xy_cpml_metric(eng, ctx, coeffs):
         eng.hz,
         ctx.metrics,
         ctx.boundary.metallic_edges_2d,
+        ctx.boundary.pmc_edges,
         terms=ctx.boundary.cpml.e_terms,
         psi_e_terms=eng.cpml_psi_e_terms,
     )

--- a/beamz/simulation/model.py
+++ b/beamz/simulation/model.py
@@ -46,6 +46,7 @@ class DomainSpec:
     plane_2d: str
     coordinate_offset: tuple[float, float, float]
     polarization_2d: str = "tm"
+    symmetry: tuple[int, int, int] = (0, 0, 0)
 
 
 @dataclass(frozen=True, slots=True)

--- a/beamz/simulation/model.py
+++ b/beamz/simulation/model.py
@@ -486,6 +486,7 @@ class CpmlPlan:
 @dataclass(frozen=True, slots=True, eq=False)
 class BoundaryPlan:
     metallic_edges_2d: frozenset[str]
+    pmc_edges: frozenset[str]
     cpml: CpmlPlan
     metallic: MetallicPlan
     logical_component_shapes: Mapping[str, tuple[int, ...]]

--- a/beamz/simulation/results.py
+++ b/beamz/simulation/results.py
@@ -15,8 +15,8 @@ from beamz.design.grid import RectilinearGrid
 from beamz.devices._immutable import immutable_snapshot, readonly_array
 from beamz.devices._placement import SnappedRegion
 from beamz.devices.monitors.compiler import CompiledMonitorSpec
-from beamz.devices.monitors.monitors import _Monitor
-from beamz.lattice import canonical_component_2d
+from beamz.devices.monitors.monitors import FieldRecorder, _Monitor
+from beamz.lattice import canonical_component_2d, component_shapes
 
 from .model import CompiledGrid, SimulationState
 from .observe import (
@@ -361,6 +361,12 @@ class SimulationMetadata:
     grid : RectilinearGrid, optional
         Exact physical grid used by the simulation. Older manually constructed
         metadata may omit it and fall back to ``resolution``.
+    symmetry : tuple of int
+        Reflection parity used by the reduced simulation in physical x/y/z order.
+    symmetry_center : tuple of float
+        Public coordinates of the three domain-center reflection planes.
+    full_grid : RectilinearGrid, optional
+        Original full-domain grid retained when ``grid`` is symmetry-reduced.
 
     Notes
     -----
@@ -381,12 +387,21 @@ class SimulationMetadata:
     fields: FieldMetadata
     polarization_2d: str = "tm"
     grid: RectilinearGrid | None = None
+    symmetry: tuple[int, int, int] = (0, 0, 0)
+    symmetry_center: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    full_grid: RectilinearGrid | None = None
 
     def __post_init__(self):
         if not isinstance(self.fields, FieldMetadata):
             raise TypeError("SimulationMetadata.fields must be FieldMetadata.")
         if self.grid is not None and not isinstance(self.grid, RectilinearGrid):
             raise TypeError("SimulationMetadata.grid must be RectilinearGrid or None.")
+        if self.full_grid is not None and not isinstance(
+            self.full_grid, RectilinearGrid
+        ):
+            raise TypeError(
+                "SimulationMetadata.full_grid must be a RectilinearGrid or None."
+            )
         offset = tuple(float(value) for value in self.coordinate_offset)
         if len(offset) != 3:
             raise ValueError(
@@ -410,6 +425,18 @@ class SimulationMetadata:
         object.__setattr__(self, "plane_2d", plane_2d)
         object.__setattr__(self, "polarization_2d", polarization_2d)
         object.__setattr__(self, "coordinate_offset", offset)
+        symmetry = tuple(int(value) for value in self.symmetry)
+        if len(symmetry) != 3 or any(value not in {-1, 0, 1} for value in symmetry):
+            raise ValueError(
+                "SimulationMetadata.symmetry must contain three parity values."
+            )
+        center = tuple(float(value) for value in self.symmetry_center)
+        if len(center) != 3 or not np.all(np.isfinite(center)):
+            raise ValueError(
+                "SimulationMetadata.symmetry_center must be a finite 3-tuple."
+            )
+        object.__setattr__(self, "symmetry", symmetry)
+        object.__setattr__(self, "symmetry_center", center)
         object.__setattr__(self, "time", time)
 
     def canonical_spec(self):
@@ -433,6 +460,9 @@ class SimulationMetadata:
             self.depth,
             self.fields,
             self.grid,
+            self.symmetry,
+            self.symmetry_center,
+            self.full_grid,
         )
 
     def __eq__(self, other):
@@ -486,6 +516,10 @@ class SimulationMetadata:
         fields = runtime_fields
         design = simulation.design
         offset = simulation.coordinate_offset
+        simulation_grid = simulation.grid
+        full_grid = simulation_grid.translated(
+            tuple(-value for value in simulation_grid.origin)
+        )
         grid_shape = tuple(int(v) for v in np.asarray(fields.permittivity).shape)
         components = ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz")
         component_shapes = {}
@@ -530,6 +564,12 @@ class SimulationMetadata:
             # Field arrays are indexed on the compiler's normalized geometry. Imported
             # material grids may retain a nonzero public origin on ``simulation.grid``.
             grid=runtime_fields.geometry,
+            symmetry=simulation.symmetry,
+            symmetry_center=tuple(
+                0.5 * size - shift
+                for size, shift in zip(simulation.size, offset, strict=True)
+            ),
+            full_grid=full_grid,
         )
 
 
@@ -1069,6 +1109,115 @@ class SimulationResults:
             If ``name`` is absent from :attr:`monitors`.
         """
         return self.monitors[str(name)]
+
+    @property
+    def symmetry_expanded(self) -> SimulationResults:
+        """Return domain field recordings reconstructed across mirror planes.
+
+        Full-domain :class:`FieldRecorder` arrays are reflected with the vectorial
+        electric/magnetic component signs implied by the originating simulation.
+        Scalar material arrays are mirrored evenly. Integrated monitor quantities
+        remain unchanged because they represent physical acquisitions rather than
+        stored field support.
+
+        Returns
+        -------
+        SimulationResults
+            Result view whose domain recordings and spatial metadata cover the
+            original full simulation domain.
+        """
+        symmetry = self.metadata.symmetry
+        if not any(symmetry):
+            return self
+
+        from beamz.simulation.symmetry import expand_cell_array, expand_field_array
+
+        expanded_monitors = {}
+        for name, result in self.monitors.items():
+            monitor = result.monitor
+            if (
+                isinstance(monitor, FieldRecorder)
+                and monitor.region == "domain"
+                and result.fields
+            ):
+                fields = {
+                    component: expand_field_array(
+                        values,
+                        component,
+                        symmetry,
+                        is_3d=self.metadata.is_3d,
+                        plane_2d=self.metadata.plane_2d,
+                    )
+                    for component, values in result.fields.items()
+                }
+                result = replace(result, fields=fields)
+            expanded_monitors[name] = result
+
+        full_grid = self.metadata.full_grid or self.metadata.grid
+        if full_grid is None:
+            raise RuntimeError(
+                "Symmetry expansion requires the original full-domain grid."
+            )
+        full_shape = (
+            full_grid.shape_zyx
+            if self.metadata.is_3d
+            else (full_grid.shape[1], full_grid.shape[0])
+        )
+        canonical_shapes = component_shapes(full_shape, self.metadata.polarization_2d)
+        public_shapes = {}
+        for component in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
+            canonical = (
+                component
+                if self.metadata.is_3d
+                else canonical_component_2d(
+                    component,
+                    self.metadata.plane_2d,
+                    self.metadata.polarization_2d,
+                )
+            )
+            public_shapes[component] = (
+                (1, 1) if canonical is None else canonical_shapes[canonical]
+            )
+        materials = self.metadata.fields.materials
+        if materials is not None:
+            materials = MaterialRegion(
+                expand_cell_array(
+                    materials.permittivity,
+                    symmetry,
+                    is_3d=self.metadata.is_3d,
+                    plane_2d=self.metadata.plane_2d,
+                ),
+                expand_cell_array(
+                    materials.permeability,
+                    symmetry,
+                    is_3d=self.metadata.is_3d,
+                    plane_2d=self.metadata.plane_2d,
+                ),
+                (0,) * len(full_shape),
+                full_shape,
+            )
+        metadata = replace(
+            self.metadata,
+            symmetry=(0, 0, 0),
+            grid=full_grid,
+            fields=FieldMetadata(
+                grid_shape=full_shape,
+                component_shapes=public_shapes,
+                materials=materials,
+            ),
+        )
+        return replace(self, metadata=metadata, monitors=expanded_monitors)
+
+    @property
+    def symmetry_expanded_copy(self) -> SimulationResults:
+        """Return an explicit immutable copy with mirror symmetry expanded.
+
+        Returns
+        -------
+        SimulationResults
+            Expanded result detached from this result container.
+        """
+        return replace(self.symmetry_expanded)
 
     def launched_power(self, source: int = 0) -> float:
         """Return the internally calibrated net power leaving a mode source.

--- a/beamz/simulation/results.py
+++ b/beamz/simulation/results.py
@@ -16,7 +16,11 @@ from beamz.devices._immutable import immutable_snapshot, readonly_array
 from beamz.devices._placement import SnappedRegion
 from beamz.devices.monitors.compiler import CompiledMonitorSpec
 from beamz.devices.monitors.monitors import FieldRecorder, _Monitor
-from beamz.lattice import canonical_component_2d, component_shapes
+from beamz.lattice import (
+    canonical_component_2d,
+    component_shapes,
+    grid_axes_in_physical_frame_2d,
+)
 
 from .model import CompiledGrid, SimulationState
 from .observe import (
@@ -271,6 +275,65 @@ def material_region_for_monitor(simulation, monitor: _Monitor, *, runtime_fields
         permeability_region,
         tuple(origin),
         full_shape,
+    )
+
+
+def _expand_2d_monitor_dft(
+    result: MonitorResults,
+    metadata: SimulationMetadata,
+) -> MonitorResults:
+    """Expand a full-span 2D line monitor's colocated DFT samples."""
+    if metadata.is_3d or not result.dft_fields:
+        return result
+    monitor = result.monitor
+    normal_axis = monitor.plane_normal
+    active_axes = tuple(metadata.plane_2d)
+    tangent_axes = tuple(axis for axis in active_axes if axis != normal_axis)
+    if len(tangent_axes) != 1:
+        return result
+    physical_axis = tangent_axes[0]
+    axis_index = {"x": 0, "y": 1, "z": 2}[physical_axis]
+    parity = metadata.symmetry[axis_index]
+    if not parity:
+        return result
+    extent = (metadata.width, metadata.height, metadata.depth)[axis_index]
+    plane = 0.5 * extent
+    lower = monitor.center[axis_index] - 0.5 * monitor.size[axis_index]
+    upper = monitor.center[axis_index] + 0.5 * monitor.size[axis_index]
+    tolerance = 1e-12 * max(abs(extent), 1.0)
+    if not (lower < plane + tolerance and upper > plane - tolerance):
+        return result
+    full_grid = metadata.full_grid or metadata.grid
+    if full_grid is None:
+        return result
+    grid_x, grid_y, _ = grid_axes_in_physical_frame_2d(metadata.plane_2d)
+    grid_axis = {grid_x: "x", grid_y: "y"}[physical_axis]
+    spacing = float(np.min(full_grid.cell_widths(grid_axis)))
+    desired_count = int(round(float(monitor.size[axis_index]) / spacing)) + 1
+    retained_count = desired_count // 2 + 1
+
+    from beamz.simulation.symmetry import reflection_sign
+
+    def expand_mapping(mapping):
+        expanded = {}
+        for component, values in mapping.items():
+            array = np.asarray(values)
+            if array.shape[-1] == desired_count:
+                retained = array[..., :retained_count]
+            elif array.shape[-1] == retained_count:
+                retained = array
+            else:
+                expanded[component] = array
+                continue
+            reflected = np.flip(retained[..., :-1], axis=-1)
+            reflected = reflection_sign(component, physical_axis, parity) * reflected
+            expanded[component] = np.concatenate((retained, reflected), axis=-1)
+        return expanded
+
+    return replace(
+        result,
+        dft_fields=expand_mapping(result.dft_fields),
+        _raw_dft_fields=expand_mapping(result._raw_dft_fields or result.dft_fields),
     )
 
 
@@ -1151,6 +1214,7 @@ class SimulationResults:
                     for component, values in result.fields.items()
                 }
                 result = replace(result, fields=fields)
+            result = _expand_2d_monitor_dft(result, self.metadata)
             expanded_monitors[name] = result
 
         full_grid = self.metadata.full_grid or self.metadata.grid

--- a/beamz/simulation/symmetry.py
+++ b/beamz/simulation/symmetry.py
@@ -9,7 +9,11 @@ import numpy as np
 from beamz.design.discretization import MaterialGrid
 from beamz.design.grid import RectilinearGrid
 from beamz.devices.boundaries import PEC, PMC, PML, Absorber, edges_for_dimension
-from beamz.lattice import component_shapes, grid_axes_in_physical_frame_2d
+from beamz.lattice import (
+    component_axis_offsets_3d,
+    component_shapes,
+    grid_axes_in_physical_frame_2d,
+)
 
 _PHYSICAL_AXES = ("x", "y", "z")
 _COMPONENT_FOR_YEE = {
@@ -23,6 +27,81 @@ _COMPONENT_FOR_YEE = {
     "mu_hy": "Hy",
     "mu_hz": "Hz",
 }
+
+
+def reflection_sign(component: str, physical_axis: str, parity: int) -> int:
+    """Return the vector-component sign under one requested reflection."""
+    component = str(component)
+    physical_axis = str(physical_axis)
+    normal = component[1].lower() == physical_axis
+    if component.startswith("E"):
+        return -int(parity) if normal else int(parity)
+    if component.startswith("H"):
+        return int(parity) if normal else -int(parity)
+    raise ValueError(f"Unsupported electromagnetic component {component!r}.")
+
+
+def _array_axis_for_physical(
+    physical_axis: str, *, ndim: int, is_3d: bool, plane_2d: str
+) -> int:
+    storage_axis = _storage_axis_for_physical(
+        physical_axis, is_3d=is_3d, plane_2d=plane_2d
+    )
+    spatial_ndim = 3 if is_3d else 2
+    return int(ndim - spatial_ndim + storage_axis)
+
+
+def expand_field_array(
+    values,
+    component: str,
+    symmetry: tuple[int, int, int],
+    *,
+    is_3d: bool,
+    plane_2d: str,
+):
+    """Mirror one reduced E/H array into the full physical domain."""
+    expanded = np.asarray(values)
+    offsets = component_axis_offsets_3d(component)
+    for index, physical_axis in enumerate(_PHYSICAL_AXES):
+        parity = int(symmetry[index])
+        if not parity:
+            continue
+        axis = _array_axis_for_physical(
+            physical_axis,
+            ndim=expanded.ndim,
+            is_3d=is_3d,
+            plane_2d=plane_2d,
+        )
+        has_plane_sample = offsets[physical_axis] == 0.0
+        retained = [slice(None)] * expanded.ndim
+        if has_plane_sample:
+            retained[axis] = slice(0, -1)
+        reflected = np.flip(expanded[tuple(retained)], axis=axis)
+        reflected = reflection_sign(component, physical_axis, parity) * reflected
+        expanded = np.concatenate((expanded, reflected), axis=axis)
+    return expanded
+
+
+def expand_cell_array(
+    values,
+    symmetry: tuple[int, int, int],
+    *,
+    is_3d: bool,
+    plane_2d: str,
+):
+    """Mirror a scalar cell-centered array into the full domain."""
+    expanded = np.asarray(values)
+    for index, physical_axis in enumerate(_PHYSICAL_AXES):
+        if not int(symmetry[index]):
+            continue
+        axis = _array_axis_for_physical(
+            physical_axis,
+            ndim=expanded.ndim,
+            is_3d=is_3d,
+            plane_2d=plane_2d,
+        )
+        expanded = np.concatenate((expanded, np.flip(expanded, axis=axis)), axis=axis)
+    return expanded
 
 
 def symmetry_cut_edges(
@@ -81,9 +160,7 @@ def _storage_axis_for_physical(
     return {grid_x: 1, grid_y: 0}[physical_axis]
 
 
-def _grid_axis_for_physical(
-    physical_axis: str, *, is_3d: bool, plane_2d: str
-) -> str:
+def _grid_axis_for_physical(physical_axis: str, *, is_3d: bool, plane_2d: str) -> str:
     if is_3d:
         return physical_axis
     grid_x, grid_y, _ = grid_axes_in_physical_frame_2d(plane_2d)
@@ -111,9 +188,7 @@ def _crop(values, target_shape: tuple[int, ...], *, prefix: int = 0):
     array = np.asarray(values)
     if array.ndim == 0:
         return array
-    slices = (slice(None),) * prefix + tuple(
-        slice(0, size) for size in target_shape
-    )
+    slices = (slice(None),) * prefix + tuple(slice(0, size) for size in target_shape)
     return array[slices]
 
 
@@ -156,9 +231,7 @@ def reduce_material_grid(
             1e-12 * max(float(np.max(np.abs(edges))), 1.0),
             64.0 * np.finfo(float).eps,
         )
-        if not np.allclose(
-            edges + edges[::-1], 2.0 * center, rtol=0.0, atol=tolerance
-        ):
+        if not np.allclose(edges + edges[::-1], 2.0 * center, rtol=0.0, atol=tolerance):
             raise ValueError(
                 f"Simulation grid must be mirror symmetric along {physical_axis}."
             )
@@ -192,9 +265,7 @@ def reduce_material_grid(
             if axis in reduced_grid_axes
             else edges
         )
-    reduced_grid = RectilinearGrid(
-        new_edges["x"], new_edges["y"], new_edges["z"]
-    )
+    reduced_grid = RectilinearGrid(new_edges["x"], new_edges["y"], new_edges["z"])
     reduced_shape = (
         reduced_grid.shape_zyx
         if is_3d

--- a/beamz/simulation/symmetry.py
+++ b/beamz/simulation/symmetry.py
@@ -1,0 +1,235 @@
+"""Reflection-symmetry validation and reduced-lattice construction."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+
+from beamz.design.discretization import MaterialGrid
+from beamz.design.grid import RectilinearGrid
+from beamz.devices.boundaries import PEC, PMC, PML, Absorber, edges_for_dimension
+from beamz.lattice import component_shapes, grid_axes_in_physical_frame_2d
+
+_PHYSICAL_AXES = ("x", "y", "z")
+_COMPONENT_FOR_YEE = {
+    "eps_x": "Ex",
+    "eps_y": "Ey",
+    "eps_z": "Ez",
+    "sig_x": "Ex",
+    "sig_y": "Ey",
+    "sig_z": "Ez",
+    "mu_hx": "Hx",
+    "mu_hy": "Hy",
+    "mu_hz": "Hz",
+}
+
+
+def symmetry_cut_edges(
+    symmetry: tuple[int, int, int], *, is_3d: bool, plane_2d: str
+) -> dict[str, int]:
+    """Return retained-half high faces and their requested parity."""
+    if is_3d:
+        edge_for_physical = {"x": "right", "y": "top", "z": "back"}
+    else:
+        grid_x, grid_y, _ = grid_axes_in_physical_frame_2d(plane_2d)
+        edge_for_physical = {grid_x: "right", grid_y: "top"}
+    return {
+        edge_for_physical[axis]: int(symmetry[index])
+        for index, axis in enumerate(_PHYSICAL_AXES)
+        if int(symmetry[index]) and axis in edge_for_physical
+    }
+
+
+def symmetry_boundaries(
+    boundaries,
+    symmetry: tuple[int, int, int],
+    *,
+    is_3d: bool,
+    plane_2d: str,
+):
+    """Remove absorbers from cut faces and install parity boundary conditions."""
+    cuts = symmetry_cut_edges(symmetry, is_3d=is_3d, plane_2d=plane_2d)
+    if not cuts:
+        return tuple(boundaries)
+    cut_names = set(cuts)
+    trimmed = []
+    for boundary in boundaries:
+        if isinstance(boundary, (PML, Absorber)):
+            edges = tuple(
+                edge
+                for edge in edges_for_dimension(boundary.edges, is_3d)
+                if edge not in cut_names
+            )
+            boundary = replace(boundary, edges=edges)
+        trimmed.append(boundary)
+    pec = tuple(edge for edge, parity in cuts.items() if parity == -1)
+    pmc = tuple(edge for edge, parity in cuts.items() if parity == 1)
+    if pec:
+        trimmed.append(PEC(edges=pec))
+    if pmc:
+        trimmed.append(PMC(edges=pmc))
+    return tuple(trimmed)
+
+
+def _storage_axis_for_physical(
+    physical_axis: str, *, is_3d: bool, plane_2d: str
+) -> int:
+    if is_3d:
+        return {"x": 2, "y": 1, "z": 0}[physical_axis]
+    grid_x, grid_y, _ = grid_axes_in_physical_frame_2d(plane_2d)
+    return {grid_x: 1, grid_y: 0}[physical_axis]
+
+
+def _grid_axis_for_physical(
+    physical_axis: str, *, is_3d: bool, plane_2d: str
+) -> str:
+    if is_3d:
+        return physical_axis
+    grid_x, grid_y, _ = grid_axes_in_physical_frame_2d(plane_2d)
+    return {grid_x: "x", grid_y: "y"}[physical_axis]
+
+
+def _assert_mirrored(values, axis: int, *, name: str) -> None:
+    array = np.asarray(values)
+    if array.ndim == 0 or array.shape[axis] <= 1:
+        return
+    scale = max(float(np.max(np.abs(array))), 1.0)
+    if not np.allclose(
+        array,
+        np.flip(array, axis=axis),
+        rtol=1e-7,
+        atol=1e-9 * scale,
+    ):
+        raise ValueError(
+            f"Simulation symmetry requires {name} to be mirror symmetric "
+            f"along storage axis {axis}."
+        )
+
+
+def _crop(values, target_shape: tuple[int, ...], *, prefix: int = 0):
+    array = np.asarray(values)
+    if array.ndim == 0:
+        return array
+    slices = (slice(None),) * prefix + tuple(
+        slice(0, size) for size in target_shape
+    )
+    return array[slices]
+
+
+def reduce_material_grid(
+    material_grid: MaterialGrid,
+    symmetry: tuple[int, int, int],
+    *,
+    is_3d: bool,
+    plane_2d: str,
+) -> MaterialGrid:
+    """Validate reflection symmetry and retain the low-coordinate half per axis."""
+    if not any(symmetry):
+        return material_grid
+    if material_grid.uses_full_permittivity:
+        raise ValueError(
+            "Simulation symmetry does not yet support off-diagonal permittivity."
+        )
+    assert material_grid.grid is not None
+    grid = material_grid.grid
+    storage_axes: list[int] = []
+    reduced_grid_axes: set[str] = set()
+    for index, physical_axis in enumerate(_PHYSICAL_AXES):
+        if not symmetry[index]:
+            continue
+        storage_axis = _storage_axis_for_physical(
+            physical_axis, is_3d=is_3d, plane_2d=plane_2d
+        )
+        grid_axis = _grid_axis_for_physical(
+            physical_axis, is_3d=is_3d, plane_2d=plane_2d
+        )
+        edges = np.asarray(grid.axis_edges(grid_axis), dtype=float)
+        cell_count = int(edges.size - 1)
+        if cell_count % 2:
+            raise ValueError(
+                f"Simulation symmetry along {physical_axis} requires an even cell "
+                f"count; got {cell_count}."
+            )
+        center = 0.5 * float(edges[0] + edges[-1])
+        tolerance = max(
+            1e-12 * max(float(np.max(np.abs(edges))), 1.0),
+            64.0 * np.finfo(float).eps,
+        )
+        if not np.allclose(
+            edges + edges[::-1], 2.0 * center, rtol=0.0, atol=tolerance
+        ):
+            raise ValueError(
+                f"Simulation grid must be mirror symmetric along {physical_axis}."
+            )
+        storage_axes.append(storage_axis)
+        reduced_grid_axes.add(grid_axis)
+
+    cell_fields = {
+        "permittivity": material_grid.permittivity,
+        "conductivity": material_grid.conductivity,
+        "permeability": material_grid.permeability,
+    }
+    for name, values in cell_fields.items():
+        for axis in storage_axes:
+            _assert_mirrored(values, axis, name=name)
+    for name, values in material_grid.yee_materials.items():
+        for axis in storage_axes:
+            _assert_mirrored(values, axis, name=name)
+    for family, mapping in (
+        ("tensor", material_grid.tensors),
+        ("Yee tensor", material_grid.yee_tensors),
+    ):
+        for name, values in mapping.items():
+            for axis in storage_axes:
+                _assert_mirrored(values, axis + 1, name=f"{family} {name}")
+
+    new_edges = {}
+    for axis_index, axis in enumerate(_PHYSICAL_AXES):
+        edges = np.asarray(grid.axis_edges(axis))
+        new_edges[axis] = (
+            edges[: grid.shape[axis_index] // 2 + 1]
+            if axis in reduced_grid_axes
+            else edges
+        )
+    reduced_grid = RectilinearGrid(
+        new_edges["x"], new_edges["y"], new_edges["z"]
+    )
+    reduced_shape = (
+        reduced_grid.shape_zyx
+        if is_3d
+        else (reduced_grid.shape[1], reduced_grid.shape[0])
+    )
+    reduced_component_shapes = component_shapes(
+        reduced_shape, material_grid.polarization or "tm"
+    )
+    yee_materials = {
+        name: _crop(values, reduced_component_shapes[_COMPONENT_FOR_YEE[name]])
+        for name, values in material_grid.yee_materials.items()
+    }
+    tensors = {
+        name: _crop(values, reduced_shape, prefix=1)
+        for name, values in material_grid.tensors.items()
+    }
+    yee_tensors = {}
+    for name, values in material_grid.yee_tensors.items():
+        target = (
+            tuple(size + 1 for size in reduced_shape)
+            if name == "eps_node"
+            else reduced_component_shapes[_COMPONENT_FOR_YEE[name]]
+        )
+        yee_tensors[name] = _crop(values, target, prefix=1)
+    return MaterialGrid(
+        permittivity=_crop(material_grid.permittivity, reduced_shape),
+        conductivity=_crop(material_grid.conductivity, reduced_shape),
+        permeability=_crop(material_grid.permeability, reduced_shape),
+        resolution=material_grid.resolution,
+        shape=reduced_shape,
+        yee_materials=yee_materials,
+        tensors=tensors,
+        smoothing=material_grid.smoothing,
+        origin=reduced_grid.origin,
+        polarization=material_grid.polarization,
+        yee_tensors=yee_tensors,
+        grid=reduced_grid,
+    )

--- a/docs/mirror-symmetry.md
+++ b/docs/mirror-symmetry.md
@@ -1,0 +1,77 @@
+# Mirror Symmetry
+
+A simulation whose materials, sources, and requested solution are mirror
+symmetric can solve only one half of each symmetric axis. This reduces the
+number of simulated cells by approximately a factor of two per axis: two active
+axes reduce a 2D grid to one quarter, while three active axes reduce a 3D grid
+to one eighth.
+
+Set `Simulation.symmetry` with one entry for each physical axis `(x, y, z)`:
+
+- `0` disables reduction on that axis.
+- `1` selects even electric-field parity across the center plane.
+- `-1` selects odd electric-field parity across the center plane.
+
+For example, this solves the lower `x` and `y` quarters of a centered 2D domain:
+
+```python
+simulation = bz.Simulation(
+    domain=(4 * bz.um, 4 * bz.um),
+    resolution=0.2 * bz.um,
+    time=time,
+    sources=(centered_source,),
+    monitors=(bz.FieldRecorder(("Ez", "Hx", "Hy"), name="fields"),),
+    boundaries=(bz.PML(edges="all"),),
+    symmetry=(1, 1, 0),
+)
+
+results = simulation.run()
+full_results = results.symmetry_expanded
+ez = full_results["fields"].fields["Ez"]
+```
+
+The input domain remains the full physical domain. BEAMZ validates its material
+grid, retains the lower half of each selected axis, and replaces the absorbing
+boundary at a symmetry cut with the appropriate PEC or PMC condition. Source
+and monitor coordinates therefore stay in the same full-domain coordinate
+system as an unreduced simulation.
+
+`run()` returns the data actually computed on the reduced grid. Use
+`results.symmetry_expanded` (or `results.symmetry_expanded_copy()`) to create an
+immutable full-domain view of domain field recordings, retained material data,
+and supported full-span 2D frequency monitors. Vector components receive the
+correct reflection signs and samples on the symmetry plane are not duplicated.
+
+## Choosing parity
+
+Parity describes the electric vector under reflection, not whether every
+component is visually even. For reflection normal to `x`:
+
+| `symmetry[0]` | Tangential `Ey`, `Ez` | Normal `Ex` | Cut boundary |
+| --- | --- | --- | --- |
+| `1` | even | odd | PMC |
+| `-1` | odd | even | PEC |
+
+Magnetic-vector component signs are complementary. The same rule rotates with
+the normal axis. A centered scalar `Ez` source in a 2D TM simulation is even;
+an odd excitation can be made from mirrored sources with opposite signals.
+
+## Validation and current scope
+
+- Every selected axis must have an even number of material cells, and material
+  arrays must be exactly mirror symmetric on that axis.
+- The symmetry plane is the center plane of the domain. Arbitrary cut planes,
+  translated planes, and rotational or periodic symmetry are not yet supported.
+- The geometry, all sources, and the intended mode must share the selected
+  parity. Material symmetry is checked automatically; source parity remains the
+  user's responsibility.
+- In 2D, the inactive physical axis must use parity `0`. Physical-axis tuples
+  work consistently for `xy`, `xz`, and `yz` planes.
+- Reduced-domain symmetry and standalone PMC boundaries currently execute with
+  the JAX backend. `backend="auto"` selects it automatically; requesting a CUDA
+  kernel explicitly raises a clear error.
+- Off-diagonal anisotropic permittivity is not supported by symmetry reduction.
+
+See the runnable
+[`mirror_symmetry.py` example](https://github.com/beamzorg/beamz/blob/main/examples/2D_basics/mirror_symmetry.py)
+for a full-versus-reduced comparison.

--- a/examples/2D_basics/mirror_symmetry.py
+++ b/examples/2D_basics/mirror_symmetry.py
@@ -1,0 +1,53 @@
+"""Solve one quarter of a centered 2D problem and expand its results."""
+
+import os
+
+import numpy as np
+
+import beamz as bz
+
+test_mode = os.environ.get("BEAMZ_DOCS_TEST") == "1"
+resolution = (0.5 if test_mode else 0.1) * bz.um
+steps = 8 if test_mode else 120
+time = np.arange(steps, dtype=float) * 1e-16
+signal = np.zeros(steps, dtype=float)
+signal[1] = 1.0
+
+source = bz.GaussianSource(
+    position=(0.0, 0.0),
+    width=0.4 * bz.um,
+    signal=signal,
+)
+recorder = bz.FieldRecorder(("Ez", "Hx", "Hy"), interval=1, name="fields")
+
+common = dict(
+    domain=(4 * bz.um, 4 * bz.um),
+    resolution=resolution,
+    time=time,
+    sources=(source,),
+    monitors=(recorder,),
+    boundaries=(bz.PEC(),),
+)
+full_simulation = bz.Simulation(**common)
+reduced_simulation = bz.Simulation(**common, symmetry=(1, 1, 0))
+
+full_shape = full_simulation.to_request().materials.shape
+reduced_shape = reduced_simulation.to_request().materials.shape
+assert np.prod(full_shape) == 4 * np.prod(reduced_shape)
+
+full_results = full_simulation.run(progress=False, performance=False)
+reduced_results = reduced_simulation.run(progress=False, performance=False)
+expanded_results = reduced_results.symmetry_expanded
+assert expanded_results.metadata.fields.grid_shape == full_shape
+assert expanded_results["fields"].fields["Ez"].shape[1:] == tuple(
+    size + 1 for size in full_shape
+)
+np.testing.assert_allclose(
+    expanded_results["fields"].fields["Ez"],
+    full_results["fields"].fields["Ez"],
+    rtol=2e-6,
+    atol=2e-12,
+)
+
+print(f"material cells: {full_shape} -> {reduced_shape}")
+print(f"expanded Ez frames: {expanded_results['fields'].fields['Ez'].shape}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ theme:
 
 nav:
   - Getting Started: getting-started.md
+  - Mirror Symmetry: mirror-symmetry.md
   - Migrating to v0.5: migrating-to-v0.5.md
   - Automatic Graded Meshing: graded-meshing.md
 

--- a/tests/contracts/public_api_registry.py
+++ b/tests/contracts/public_api_registry.py
@@ -174,6 +174,7 @@ CONFIGURATION_CASES = (
     PublicConfigCase("ModeSpec", bz.ModeSpec),
     PublicConfigCase("PML", bz.PML),
     PublicConfigCase("PEC", bz.PEC),
+    PublicConfigCase("PMC", bz.PMC),
     PublicConfigCase("Absorber", bz.Absorber),
 )
 

--- a/tests/contracts/test_pec.py
+++ b/tests/contracts/test_pec.py
@@ -1,12 +1,13 @@
 import pytest
 
-from beamz import PEC, PML, Absorber
+from beamz import PEC, PMC, PML, Absorber
 
 pytestmark = pytest.mark.unit
 
 
 def test_pec_thickness_is_zero_for_api_parity():
     assert PEC().thickness == pytest.approx(0.0)
+    assert PMC().thickness == pytest.approx(0.0)
 
 
 def test_pec_all_edges_resolve_by_dimensionality():
@@ -33,7 +34,7 @@ def test_pec_explicit_edges_are_preserved():
     assert pec._get_edges_for_dimensionality(True) == ["left", "front"]
 
 
-@pytest.mark.parametrize("boundary_type", [PEC, PML, Absorber])
+@pytest.mark.parametrize("boundary_type", [PEC, PMC, PML, Absorber])
 def test_boundary_edges_are_normalized_and_validated(boundary_type):
     boundary = boundary_type(edges=["LEFT", "Top"])
     assert boundary.edges == ("left", "top")
@@ -42,7 +43,7 @@ def test_boundary_edges_are_normalized_and_validated(boundary_type):
         boundary_type(edges=["lef"])
 
 
-@pytest.mark.parametrize("boundary_type", [PEC, PML, Absorber])
+@pytest.mark.parametrize("boundary_type", [PEC, PMC, PML, Absorber])
 def test_out_of_plane_boundary_edges_require_3d(boundary_type):
     boundary = boundary_type(edges=["front"])
 

--- a/tests/contracts/test_public_api_freeze.py
+++ b/tests/contracts/test_public_api_freeze.py
@@ -64,6 +64,7 @@ EXPECTED_EXPORTS = {
         "RunTermination",
         "PML",
         "PEC",
+        "PMC",
         "Absorber",
         "display_status",
         "create_plain_progress",
@@ -157,6 +158,7 @@ EXPECTED_EXPORTS = {
         "inf",
         "PML",
         "PEC",
+        "PMC",
         "Absorber",
     ),
 }

--- a/tests/contracts/test_simulation_api.py
+++ b/tests/contracts/test_simulation_api.py
@@ -69,7 +69,14 @@ def test_simulation_symmetry_is_immutable_validated_and_part_of_request():
     assert sim.updated_copy(symmetry=(0, 1, 0)).symmetry == (0, 1, 0)
     assert sim != _simulation(symmetry=(0, 0, 0))
 
-    for invalid in ((0, 0), (0, 0, 0, 0), (0, 2, 0), "bad"):
+    for invalid in (
+        (0, 0),
+        (0, 0, 0, 0),
+        (0, 2, 0),
+        (0, 0.5, 0),
+        (0, True, 0),
+        "bad",
+    ):
         with pytest.raises(ValueError, match="symmetry.*three values"):
             _simulation(symmetry=invalid)
 

--- a/tests/contracts/test_simulation_api.py
+++ b/tests/contracts/test_simulation_api.py
@@ -61,6 +61,29 @@ def test_simulation_rejects_invalid_plane_and_resolution():
             _simulation(grid_spec=GridSpec.uniform(resolution))
 
 
+def test_simulation_symmetry_is_immutable_validated_and_part_of_request():
+    sim = _simulation(symmetry=(1, -1, 0))
+
+    assert sim.symmetry == (1, -1, 0)
+    assert sim.to_request().domain.symmetry == (1, -1, 0)
+    assert sim.updated_copy(symmetry=(0, 1, 0)).symmetry == (0, 1, 0)
+    assert sim != _simulation(symmetry=(0, 0, 0))
+
+    for invalid in ((0, 0), (0, 0, 0, 0), (0, 2, 0), "bad"):
+        with pytest.raises(ValueError, match="symmetry.*three values"):
+            _simulation(symmetry=invalid)
+
+
+def test_2d_symmetry_rejects_inactive_physical_axis():
+    with pytest.raises(ValueError, match="inactive z-axis"):
+        _simulation(symmetry=(0, 0, 1))
+
+    xz = _simulation(plane_2d="xz", symmetry=(1, 0, -1))
+    assert xz.symmetry == (1, 0, -1)
+    with pytest.raises(ValueError, match="inactive y-axis"):
+        _simulation(plane_2d="xz", symmetry=(0, 1, 0))
+
+
 def test_simulation_rejects_conflicting_or_invalid_time_specifications():
     with pytest.raises(ValueError, match="only one of time.*run_time"):
         _simulation(run_time=1e-15)

--- a/tests/contracts/test_simulation_architecture_contracts.py
+++ b/tests/contracts/test_simulation_architecture_contracts.py
@@ -13,6 +13,7 @@ import pytest
 import beamz.simulation.api as simulation_core
 from beamz import (
     PEC,
+    PMC,
     PML,
     Absorber,
     Box,
@@ -734,7 +735,9 @@ def test_boundaries_are_canonical_immutable_request_specs():
 
     boundaries = sim.to_request().boundaries
     assert boundaries == tuple(sim.boundaries)
-    assert all(isinstance(boundary, (PEC, PML, Absorber)) for boundary in boundaries)
+    assert all(
+        isinstance(boundary, (PEC, PMC, PML, Absorber)) for boundary in boundaries
+    )
     assert isinstance(hash(boundaries[0]), int)
 
 

--- a/tests/contracts/test_simulation_public_api_contracts.py
+++ b/tests/contracts/test_simulation_public_api_contracts.py
@@ -22,6 +22,7 @@ STABLE_SIMULATION_EXPORTS = {
     "ModeSpec",
     "MonitorResults",
     "PEC",
+    "PMC",
     "PML",
     "Port",
     "RunTermination",
@@ -84,6 +85,7 @@ def test_public_specs_have_consistent_reexports():
     assert beamz.GaussianPulse is simulation.GaussianPulse is sources.GaussianPulse
     assert beamz.ModeSpec is simulation.ModeSpec is sources.ModeSpec
     assert beamz.PEC is simulation.PEC is devices.PEC
+    assert beamz.PMC is simulation.PMC is devices.PMC
     assert beamz.PML is simulation.PML is devices.PML
     assert beamz.Absorber is simulation.Absorber is devices.Absorber
     assert hasattr(design, "MaterialGrid")
@@ -104,6 +106,7 @@ def test_public_simulation_methods_have_reference_docstrings():
         simulation.GaussianPulse,
         simulation.ModeSpec,
         simulation.PEC,
+        simulation.PMC,
         simulation.PML,
         simulation.Absorber,
     )

--- a/tests/docs/test_mirror_symmetry_example.py
+++ b/tests/docs/test_mirror_symmetry_example.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE = ROOT / "examples" / "2D_basics" / "mirror_symmetry.py"
+
+
+def test_mirror_symmetry_example_compiles():
+    compile(EXAMPLE.read_text(encoding="utf-8"), str(EXAMPLE), "exec")
+
+
+def test_mirror_symmetry_example_executes_in_reduced_mode():
+    environment = {
+        **os.environ,
+        "BEAMZ_DOCS_TEST": "1",
+        "JAX_PLATFORMS": "cpu",
+    }
+    subprocess.run(
+        [sys.executable, str(EXAMPLE)],
+        cwd=ROOT,
+        env=environment,
+        check=True,
+        timeout=120,
+    )

--- a/tests/integration/test_simulation_symmetry.py
+++ b/tests/integration/test_simulation_symmetry.py
@@ -46,6 +46,28 @@ def test_symmetry_request_reduces_each_active_axis_and_replaces_cut_absorbers():
     )
 
 
+@pytest.mark.parametrize(
+    ("plane", "symmetry"),
+    [("xy", (1, -1, 0)), ("xz", (1, 0, -1)), ("yz", (0, 1, -1))],
+)
+def test_2d_symmetry_tuple_always_uses_physical_axes(plane, symmetry):
+    time, _ = _time_and_impulse(3)
+    request = bz.Simulation(
+        domain=(4 * bz.um, 4 * bz.um),
+        resolution=1 * bz.um,
+        time=time,
+        plane_2d=plane,
+        boundaries=(bz.PML(edges="all"),),
+        symmetry=symmetry,
+    ).to_request()
+
+    assert request.materials.shape == (2, 2)
+    assert {edge for boundary in request.boundaries for edge in boundary.edges} >= {
+        "right",
+        "top",
+    }
+
+
 def test_symmetry_rejects_asymmetric_material_data():
     epsilon = np.ones((4, 4), dtype=float)
     epsilon[0, 0] = 2.0

--- a/tests/integration/test_simulation_symmetry.py
+++ b/tests/integration/test_simulation_symmetry.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
 import beamz as bz
 from beamz.design.discretization import MaterialGrid
 from beamz.simulation.kernels import tm_xy_curl_h_to_e_2d
+from beamz.simulation.symmetry import expand_field_array
 
 pytestmark = [pytest.mark.simulation, pytest.mark.integration]
 
@@ -181,3 +183,120 @@ def test_domain_field_recorder_expands_to_full_vector_solution(parity):
             rtol=2e-6,
             atol=2e-12,
         )
+
+
+@pytest.mark.parametrize("parity", [1, -1])
+def test_reduced_3d_step_matches_full_domain_vector_update(parity):
+    time, _ = _time_and_impulse(3)
+    setup = dict(
+        domain=(4 * bz.um, 4 * bz.um, 4 * bz.um),
+        resolution=1 * bz.um,
+        time=time,
+        boundaries=(bz.PEC(),),
+    )
+    full_sim = bz.Simulation(**setup)
+    reduced_sim = bz.Simulation(**setup, symmetry=(parity, 0, 0))
+    reduced = reduced_sim.initial_state()
+    rng = np.random.default_rng(7)
+    reduced_ez = rng.normal(size=reduced.ez.shape).astype(np.float32)
+    reduced_ez[:, 0, :] = 0.0
+    reduced_ez[:, -1, :] = 0.0
+    reduced_ez[:, :, 0] = 0.0
+    if parity == -1:
+        reduced_ez[:, :, -1] = 0.0
+    full_ez = expand_field_array(
+        reduced_ez,
+        "Ez",
+        (parity, 0, 0),
+        is_3d=True,
+        plane_2d="xy",
+    )
+    reduced = reduced._replace(ez=jnp.asarray(reduced_ez))
+    full = full_sim.initial_state()._replace(ez=jnp.asarray(full_ez))
+
+    reduced_next = reduced_sim.step(reduced, backend="jax")
+    full_next = full_sim.step(full, backend="jax")
+
+    for name in ("ex", "ey", "ez", "hx", "hy", "hz"):
+        reduced_field = np.asarray(getattr(reduced_next, name))
+        full_field = np.asarray(getattr(full_next, name))
+        retained = full_field[..., : reduced_field.shape[-1]]
+        np.testing.assert_allclose(reduced_field, retained, rtol=2e-6, atol=2e-12)
+
+
+@pytest.mark.parametrize("parity", [1, -1])
+def test_reduced_2d_te_step_matches_full_domain_vector_update(parity):
+    time, _ = _time_and_impulse(3)
+    setup = dict(
+        domain=(4 * bz.um, 4 * bz.um),
+        resolution=0.5 * bz.um,
+        time=time,
+        polarization="te",
+        boundaries=(bz.PEC(),),
+    )
+    full_sim = bz.Simulation(**setup)
+    reduced_sim = bz.Simulation(**setup, symmetry=(parity, 0, 0))
+    reduced = reduced_sim.initial_state()
+    rng = np.random.default_rng(11)
+    reduced_hz = rng.normal(size=reduced.hz.shape).astype(np.float32)
+    full_hz = expand_field_array(
+        reduced_hz,
+        "Hz",
+        (parity, 0, 0),
+        is_3d=False,
+        plane_2d="xy",
+    )
+    reduced = reduced._replace(hz=jnp.asarray(reduced_hz))
+    full = full_sim.initial_state()._replace(hz=jnp.asarray(full_hz))
+
+    reduced_next = reduced_sim.step(reduced, backend="jax")
+    full_next = full_sim.step(full, backend="jax")
+
+    for name in ("ex", "ey", "hz"):
+        reduced_field = np.asarray(getattr(reduced_next, name))
+        full_field = np.asarray(getattr(full_next, name))
+        retained = full_field[:, : reduced_field.shape[1]]
+        np.testing.assert_allclose(reduced_field, retained, rtol=2e-6, atol=2e-12)
+
+
+def test_full_span_2d_flux_monitor_expands_with_physical_flux():
+    steps = 40
+    time = np.arange(steps, dtype=float) * 1e-16
+    impulse = np.zeros(steps, dtype=float)
+    impulse[1] = 1.0
+    source = bz.GaussianSource(position=(0.0, 0.0), width=0.5 * bz.um, signal=impulse)
+    monitor = bz.FluxMonitor(
+        center=(0.5 * bz.um, 0.0, 0.0),
+        size=(0.0, 4 * bz.um, 1.0),
+        freqs=(2e14,),
+        name="flux",
+    )
+    setup = dict(
+        domain=(4 * bz.um, 4 * bz.um),
+        resolution=0.2 * bz.um,
+        time=time,
+        sources=(source,),
+        monitors=(monitor,),
+        boundaries=(bz.PEC(),),
+        normalize_source=None,
+    )
+
+    full = bz.Simulation(**setup).run(progress=False, performance=False)
+    reduced = bz.Simulation(**setup, symmetry=(0, 1, 0)).run(
+        progress=False, performance=False
+    )
+    expanded = reduced.symmetry_expanded
+
+    for component in full["flux"].dft_fields:
+        np.testing.assert_allclose(
+            expanded["flux"].dft_fields[component],
+            full["flux"].dft_fields[component],
+            rtol=2e-6,
+            atol=2e-12,
+        )
+    np.testing.assert_allclose(
+        expanded["flux"].get_dft_flux(),
+        full["flux"].get_dft_flux(),
+        rtol=3e-6,
+        atol=1e-26,
+    )

--- a/tests/integration/test_simulation_symmetry.py
+++ b/tests/integration/test_simulation_symmetry.py
@@ -1,0 +1,132 @@
+"""End-to-end contracts for reduced-domain mirror symmetry."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import beamz as bz
+from beamz.design.discretization import MaterialGrid
+from beamz.simulation.kernels import tm_xy_curl_h_to_e_2d
+
+pytestmark = [pytest.mark.simulation, pytest.mark.integration]
+
+
+def _time_and_impulse(steps: int = 8):
+    time = np.arange(steps, dtype=float) * 1e-16
+    signal = np.zeros(steps, dtype=float)
+    signal[1] = 1.0
+    return time, signal
+
+
+def test_symmetry_request_reduces_each_active_axis_and_replaces_cut_absorbers():
+    time, _ = _time_and_impulse(3)
+    sim = bz.Simulation(
+        domain=(4 * bz.um, 4 * bz.um, 4 * bz.um),
+        resolution=1 * bz.um,
+        time=time,
+        boundaries=(bz.PML(edges="all", formulation="cpml"),),
+        symmetry=(1, -1, 1),
+    )
+
+    request = sim.to_request()
+
+    assert request.materials.shape == (2, 2, 2)
+    assert request.materials.grid.shape == (2, 2, 2)
+    assert request.boundaries[0].edges == ("left", "bottom", "front")
+    assert any(
+        isinstance(boundary, bz.PEC) and boundary.edges == ("top",)
+        for boundary in request.boundaries
+    )
+    assert any(
+        isinstance(boundary, bz.PMC)
+        and set(boundary.edges) == {"right", "back"}
+        for boundary in request.boundaries
+    )
+
+
+def test_symmetry_rejects_asymmetric_material_data():
+    epsilon = np.ones((4, 4), dtype=float)
+    epsilon[0, 0] = 2.0
+    material_grid = MaterialGrid(
+        permittivity=epsilon,
+        conductivity=np.zeros_like(epsilon),
+        permeability=np.ones_like(epsilon),
+        resolution=1 * bz.um,
+        shape=epsilon.shape,
+    )
+    time, _ = _time_and_impulse(3)
+    sim = bz.Simulation(
+        material_grid=material_grid,
+        time=time,
+        symmetry=(1, 0, 0),
+    )
+
+    with pytest.raises(ValueError, match="permittivity.*mirror symmetric"):
+        sim.to_request()
+
+
+def test_pmc_ghost_has_odd_magnetic_parity():
+    hx = np.zeros((2, 3), dtype=np.float32)
+    hy = np.ones((3, 2), dtype=np.float32)
+
+    ordinary = np.asarray(
+        tm_xy_curl_h_to_e_2d(hx, hy, 1.0, (3, 3), frozenset())
+    )
+    pmc = np.asarray(
+        tm_xy_curl_h_to_e_2d(
+            hx,
+            hy,
+            1.0,
+            (3, 3),
+            frozenset(),
+            frozenset({"right"}),
+        )
+    )
+
+    np.testing.assert_allclose(ordinary[:, -1], 0.0)
+    np.testing.assert_allclose(pmc[:, -1], -2.0)
+
+
+@pytest.mark.parametrize("parity", [1, -1])
+def test_reduced_2d_tm_matches_full_domain_for_even_and_odd_sources(parity):
+    time, impulse = _time_and_impulse()
+    if parity == 1:
+        sources = (
+            bz.GaussianSource(
+                position=(0.0, 0.0),
+                width=0.5 * bz.um,
+                signal=impulse,
+            ),
+        )
+    else:
+        sources = (
+            bz.GaussianSource(
+                position=(-0.5 * bz.um, 0.0),
+                width=0.3 * bz.um,
+                signal=impulse,
+            ),
+            bz.GaussianSource(
+                position=(0.5 * bz.um, 0.0),
+                width=0.3 * bz.um,
+                signal=-impulse,
+            ),
+        )
+    setup = dict(
+        domain=(4 * bz.um, 4 * bz.um),
+        resolution=0.2 * bz.um,
+        time=time,
+        sources=sources,
+        boundaries=(bz.PEC(),),
+    )
+
+    full = bz.Simulation(**setup).advance(performance=False).state
+    reduced = bz.Simulation(**setup, symmetry=(parity, 0, 0)).advance(
+        performance=False
+    ).state
+
+    for name in ("ez", "hx", "hy"):
+        full_field = np.asarray(getattr(full, name))
+        reduced_field = np.asarray(getattr(reduced, name))
+        retained = full_field[:, : reduced_field.shape[1]]
+        np.testing.assert_allclose(reduced_field, retained, rtol=2e-6, atol=2e-12)

--- a/tests/integration/test_simulation_symmetry.py
+++ b/tests/integration/test_simulation_symmetry.py
@@ -39,8 +39,7 @@ def test_symmetry_request_reduces_each_active_axis_and_replaces_cut_absorbers():
         for boundary in request.boundaries
     )
     assert any(
-        isinstance(boundary, bz.PMC)
-        and set(boundary.edges) == {"right", "back"}
+        isinstance(boundary, bz.PMC) and set(boundary.edges) == {"right", "back"}
         for boundary in request.boundaries
     )
 
@@ -70,9 +69,7 @@ def test_pmc_ghost_has_odd_magnetic_parity():
     hx = np.zeros((2, 3), dtype=np.float32)
     hy = np.ones((3, 2), dtype=np.float32)
 
-    ordinary = np.asarray(
-        tm_xy_curl_h_to_e_2d(hx, hy, 1.0, (3, 3), frozenset())
-    )
+    ordinary = np.asarray(tm_xy_curl_h_to_e_2d(hx, hy, 1.0, (3, 3), frozenset()))
     pmc = np.asarray(
         tm_xy_curl_h_to_e_2d(
             hx,
@@ -121,12 +118,66 @@ def test_reduced_2d_tm_matches_full_domain_for_even_and_odd_sources(parity):
     )
 
     full = bz.Simulation(**setup).advance(performance=False).state
-    reduced = bz.Simulation(**setup, symmetry=(parity, 0, 0)).advance(
-        performance=False
-    ).state
+    reduced = (
+        bz.Simulation(**setup, symmetry=(parity, 0, 0)).advance(performance=False).state
+    )
 
     for name in ("ez", "hx", "hy"):
         full_field = np.asarray(getattr(full, name))
         reduced_field = np.asarray(getattr(reduced, name))
         retained = full_field[:, : reduced_field.shape[1]]
         np.testing.assert_allclose(reduced_field, retained, rtol=2e-6, atol=2e-12)
+
+
+@pytest.mark.parametrize("parity", [1, -1])
+def test_domain_field_recorder_expands_to_full_vector_solution(parity):
+    time, impulse = _time_and_impulse()
+    sources = (
+        (
+            bz.GaussianSource(
+                position=(0.0, 0.0),
+                width=0.5 * bz.um,
+                signal=impulse,
+            ),
+        )
+        if parity == 1
+        else (
+            bz.GaussianSource(
+                position=(-0.5 * bz.um, 0.0),
+                width=0.3 * bz.um,
+                signal=impulse,
+            ),
+            bz.GaussianSource(
+                position=(0.5 * bz.um, 0.0),
+                width=0.3 * bz.um,
+                signal=-impulse,
+            ),
+        )
+    )
+    recorder = bz.FieldRecorder(("Ez", "Hx", "Hy"), interval=1)
+    setup = dict(
+        domain=(4 * bz.um, 4 * bz.um),
+        resolution=0.2 * bz.um,
+        time=time,
+        sources=sources,
+        monitors=(recorder,),
+        boundaries=(bz.PEC(),),
+    )
+
+    full = bz.Simulation(**setup).run(progress=False, performance=False)
+    reduced = bz.Simulation(**setup, symmetry=(parity, 0, 0)).run(
+        progress=False, performance=False
+    )
+    expanded = reduced.symmetry_expanded
+
+    assert reduced.metadata.symmetry == (parity, 0, 0)
+    assert expanded.metadata.symmetry == (0, 0, 0)
+    assert expanded.metadata.fields.grid_shape == full.metadata.fields.grid_shape
+    assert expanded.metadata.grid.shape == full.metadata.grid.shape
+    for component in recorder.components:
+        np.testing.assert_allclose(
+            expanded[recorder.name].fields[component],
+            full[recorder.name].fields[component],
+            rtol=2e-6,
+            atol=2e-12,
+        )


### PR DESCRIPTION
## Summary

- add the familiar `Simulation(symmetry=(sx, sy, sz))` workflow with physical-axis parity values `-1`, `0`, and `1`
- validate centered mirror-symmetric grids and materials, reduce each active axis by half, and replace cut-face absorbers with PEC/PMC parity boundaries
- implement parity-correct 2D TE/TM and 3D JAX field updates, including a public PMC boundary
- retain symmetry metadata and provide `symmetry_expanded` plus `symmetry_expanded_copy()` for full-domain field, material, and supported 2D DFT monitor data
- document parity selection and add a runnable full-versus-quarter-domain example

## Validation

- full-domain versus reduced-domain numerical comparisons for even and odd parity
- 2D TE, 2D TM, and 3D coverage
- one-, two-, and three-axis reduction coverage, including 8x cell reduction
- vector-field reconstruction and full-span 2D flux reconstruction
- physical-axis behavior across `xy`, `xz`, and `yz` planes
- `uv run --extra dev ruff check .`
- `uv run --extra dev pytest -q`: 1121 passed, 38 skipped, 1 xfailed
- `uv run mkdocs build --strict`

## Current limits

- symmetry execution uses JAX; `backend="auto"` selects it, while explicit CUDA requests fail clearly
- cut planes must be centered, selected axes need even cell counts, and off-diagonal anisotropic permittivity is unsupported
- material parity is validated automatically; source parity remains the caller responsibility
- arbitrary monitor reconstruction, modal normalization, CUDA parity stencils, and symmetry-aware adjoint variable accumulation remain follow-up work

Implements the core workflow from #222.