### PR TITLE
fix: refine modes on rectilinear Yee grids

### DIFF
--- a/beamz/devices/modes/_yee.py
+++ b/beamz/devices/modes/_yee.py
@@ -25,6 +25,7 @@ def refine_x_mode_at_fixed_beta(
     resolution,
     k_num,
     direction_sign,
+    transverse_cell_widths=None,
     _correct_beta=True,
 ):
     """Refine E at the selected beta, then reconstruct H from Faraday's law."""
@@ -43,6 +44,7 @@ def refine_x_mode_at_fixed_beta(
         out,
         resolution=d,
         delta=delta,
+        transverse_cell_widths=transverse_cell_widths,
     )
     eps, mu = _component_material_vectors(
         out,
@@ -129,6 +131,7 @@ def refine_x_mode_at_fixed_beta(
                 resolution=resolution,
                 k_num=k_corrected,
                 direction_sign=direction_sign,
+                transverse_cell_widths=transverse_cell_widths,
                 _correct_beta=False,
             )
             return (
@@ -197,6 +200,8 @@ def validate_x_mode_refinement(
     resolution,
     k_num,
     direction_sign,
+    transverse_cell_widths=None,
+    integration_weights=None,
     minimum_electric_overlap=None,
     minimum_magnetic_overlap=0.5,
     maximum_impedance_change=4.0,
@@ -243,8 +248,12 @@ def validate_x_mode_refinement(
         component_permittivity=component_permittivity,
         component_permeability=component_permeability,
     )
-    seed_energy_ratio = _energy_ratio(seed, eps, mu)
-    candidate_energy_ratio = _energy_ratio(candidate, eps, mu)
+    seed_energy_ratio = _energy_ratio(
+        seed, eps, mu, integration_weights=integration_weights
+    )
+    candidate_energy_ratio = _energy_ratio(
+        candidate, eps, mu, integration_weights=integration_weights
+    )
     diagnostics["seed_energy_ratio"] = seed_energy_ratio
     diagnostics["candidate_energy_ratio"] = candidate_energy_ratio
     diagnostics["energy_ratio_change"] = _ratio_change(
@@ -255,10 +264,16 @@ def validate_x_mode_refinement(
     )
 
     seed_power = _signed_x_power(
-        seed, resolution=resolution, direction_sign=direction_sign
+        seed,
+        resolution=resolution,
+        direction_sign=direction_sign,
+        integration_weights=integration_weights,
     )
     candidate_power = _signed_x_power(
-        candidate, resolution=resolution, direction_sign=direction_sign
+        candidate,
+        resolution=resolution,
+        direction_sign=direction_sign,
+        integration_weights=integration_weights,
     )
     diagnostics["seed_signed_power"] = seed_power
     diagnostics["candidate_signed_power"] = candidate_power
@@ -272,6 +287,7 @@ def validate_x_mode_refinement(
         candidate,
         resolution=float(resolution),
         delta=delta,
+        transverse_cell_widths=transverse_cell_widths,
     )
     omega_d = (
         float(omega)
@@ -313,11 +329,27 @@ def validate_x_mode_refinement(
     return not rejection_reasons, diagnostics
 
 
-def _yee_curl_operators(sparse, profiles, *, resolution, delta):
+def _yee_curl_operators(
+    sparse, profiles, *, resolution, delta, transverse_cell_widths=None
+):
     nz, ny = profiles["Ex"].shape
-    dz = _forward_difference(sparse, nz, resolution)
-    dy = _forward_difference(sparse, ny, resolution)
-    bz, by = -dz.T, -dy.T
+    if transverse_cell_widths is None:
+        dz = _forward_difference(sparse, nz, resolution)
+        dy = _forward_difference(sparse, ny, resolution)
+        bz, by = -dz.T, -dy.T
+    else:
+        widths_z, widths_y = (
+            np.asarray(values, dtype=float).reshape(-1)
+            for values in transverse_cell_widths
+        )
+        if widths_z.size != nz or widths_y.size != ny:
+            raise ValueError(
+                "Rectilinear transverse widths must match the x-normal mode plane"
+            )
+        dz = _center_to_edge_difference(sparse, widths_z)
+        dy = _center_to_edge_difference(sparse, widths_y)
+        bz = _edge_to_center_difference(sparse, widths_z)
+        by = _edge_to_center_difference(sparse, widths_y)
     iz = sparse.eye(nz, format="csc")
     iy = sparse.eye(ny, format="csc")
     izm = sparse.eye(nz - 1, format="csc")
@@ -417,11 +449,21 @@ def _rms_impedance(profiles):
     return float(electric_norm / magnetic_norm)
 
 
-def _energy_ratio(profiles, eps, mu):
+def _energy_ratio(profiles, eps, mu, *, integration_weights=None):
     electric = _component_vector(profiles, _E_COMPONENTS)
     magnetic = _component_vector(profiles, _H_COMPONENTS)
-    electric_energy = _EPS0 * float(np.real(np.vdot(electric, eps * electric)))
-    magnetic_energy = _MU0 * float(np.real(np.vdot(magnetic, mu * magnetic)))
+    electric_weights = _component_weight_vector(
+        profiles, _E_COMPONENTS, integration_weights
+    )
+    magnetic_weights = _component_weight_vector(
+        profiles, _H_COMPONENTS, integration_weights
+    )
+    electric_energy = _EPS0 * float(
+        np.real(np.vdot(electric, electric_weights * eps * electric))
+    )
+    magnetic_energy = _MU0 * float(
+        np.real(np.vdot(magnetic, magnetic_weights * mu * magnetic))
+    )
     if (
         not np.isfinite(electric_energy)
         or not np.isfinite(magnetic_energy)
@@ -441,10 +483,32 @@ def _ratio_change(candidate, seed):
     return float(max(candidate / seed, seed / candidate))
 
 
-def _signed_x_power(profiles, *, resolution, direction_sign):
-    flux = np.vdot(profiles["Hz"].reshape(-1), profiles["Ey"].reshape(-1))
-    flux -= np.vdot(profiles["Hy"].reshape(-1), profiles["Ez"].reshape(-1))
-    return float(0.5 * float(direction_sign) * np.real(flux) * float(resolution) ** 2)
+def _signed_x_power(profiles, *, resolution, direction_sign, integration_weights=None):
+    if integration_weights is None:
+        ey_weights = ez_weights = float(resolution) ** 2
+    else:
+        ey_weights = np.asarray(integration_weights["Ey"], dtype=float).reshape(-1)
+        ez_weights = np.asarray(integration_weights["Ez"], dtype=float).reshape(-1)
+    flux = np.vdot(
+        profiles["Hz"].reshape(-1),
+        ey_weights * profiles["Ey"].reshape(-1),
+    )
+    flux -= np.vdot(
+        profiles["Hy"].reshape(-1),
+        ez_weights * profiles["Ez"].reshape(-1),
+    )
+    return float(0.5 * float(direction_sign) * np.real(flux))
+
+
+def _component_weight_vector(profiles, names, integration_weights):
+    if integration_weights is None:
+        return np.ones(sum(np.asarray(profiles[name]).size for name in names))
+    return np.concatenate(
+        [
+            np.asarray(integration_weights[name], dtype=float).reshape(-1)
+            for name in names
+        ]
+    )
 
 
 def _relative_pair_residual(left, right):
@@ -466,3 +530,47 @@ def _forward_difference(sparse, count, spacing):
     cols = np.column_stack((np.arange(count - 1), np.arange(1, count))).reshape(-1)
     data = np.tile(np.asarray([-1.0, 1.0]) / spacing, count - 1)
     return sparse.csc_matrix((data, (rows, cols)), shape=(count - 1, count))
+
+
+def _center_to_edge_difference(sparse, cell_widths):
+    widths = np.asarray(cell_widths, dtype=float).reshape(-1)
+    spacing = 0.5 * (widths[:-1] + widths[1:])
+    rows = np.repeat(np.arange(widths.size - 1), 2)
+    cols = np.column_stack(
+        (np.arange(widths.size - 1), np.arange(1, widths.size))
+    ).reshape(-1)
+    data = np.column_stack((-1.0 / spacing, 1.0 / spacing)).reshape(-1)
+    return sparse.csc_matrix((data, (rows, cols)), shape=(widths.size - 1, widths.size))
+
+
+def _edge_to_center_difference(sparse, cell_widths):
+    widths = np.asarray(cell_widths, dtype=float).reshape(-1)
+    rows = np.concatenate(
+        (
+            np.asarray([0]),
+            np.repeat(np.arange(1, widths.size - 1), 2),
+            np.asarray([widths.size - 1]),
+        )
+    )
+    cols = np.concatenate(
+        (
+            np.asarray([0]),
+            np.column_stack(
+                (np.arange(widths.size - 2), np.arange(1, widths.size - 1))
+            ).reshape(-1),
+            np.asarray([widths.size - 2]),
+        )
+    )
+    data = np.concatenate(
+        (
+            np.asarray([1.0 / widths[0]]),
+            np.column_stack(
+                (
+                    -1.0 / widths[1:-1],
+                    1.0 / widths[1:-1],
+                )
+            ).reshape(-1),
+            np.asarray([-1.0 / widths[-1]]),
+        )
+    )
+    return sparse.csc_matrix((data, (rows, cols)), shape=(widths.size, widths.size - 1))

--- a/beamz/devices/modes/discrete.py
+++ b/beamz/devices/modes/discrete.py
@@ -314,13 +314,23 @@ def solve_beamz_mode(spec: ModePlaneSpec) -> DiscreteMode:
         if spec.grid is not None
         else spec.resolution
     )
+    transverse_cell_widths = None
+    if spec.grid is not None:
+        transverse_cell_widths = tuple(
+            _component_axis_measure(
+                spec,
+                "Ex",
+                transverse_axis,
+                indices["Ex"][{"z": 0, "y": 1, "x": 2}[transverse_axis]],
+            )
+            for transverse_axis in ("z", "y")
+        )
     k_num = _numeric_wave_number(omega, spec.dt, normal_spacing, selected["neff"])
     boundary_neff = _boundary_refractive_index(spec.scalar_permittivity)
     yee_refinement_eligible = (
         spec.axis == "x"
         and bool(spec.component_permittivity)
         and float(np.real(selected["neff"])) > boundary_neff
-        and (spec.grid is None or spec.grid.is_uniform)
     )
     yee_refinement_requested = bool(spec.yee_refinement)
     yee_refinement_attempted = yee_refinement_requested and yee_refinement_eligible
@@ -354,9 +364,10 @@ def solve_beamz_mode(spec: ModePlaneSpec) -> DiscreteMode:
                 component_permeability=spec.component_permeability,
                 omega=omega,
                 dt=spec.dt,
-                resolution=spec.resolution,
+                resolution=normal_spacing,
                 k_num=seed_k_num,
                 direction_sign=_direction_sign(spec.direction),
+                transverse_cell_widths=transverse_cell_widths,
             )
             yee_refinement_accepted, yee_validation = validate_x_mode_refinement(
                 seed_profiles,
@@ -366,9 +377,13 @@ def solve_beamz_mode(spec: ModePlaneSpec) -> DiscreteMode:
                 component_permeability=spec.component_permeability,
                 omega=omega,
                 dt=spec.dt,
-                resolution=spec.resolution,
+                resolution=normal_spacing,
                 k_num=candidate_k_num,
                 direction_sign=_direction_sign(spec.direction),
+                transverse_cell_widths=transverse_cell_widths,
+                integration_weights=_profile_integration_weights(
+                    spec, candidate, indices
+                ),
             )
             yee_refinement_rejection_reason = str(
                 yee_validation.get("rejection_reason", "")

--- a/tests/integration/test_mode_source_integration.py
+++ b/tests/integration/test_mode_source_integration.py
@@ -80,9 +80,25 @@ def test_3d_mode_source_suppresses_counterpropagating_power_on_both_grids(
         freqs=[frequency],
         name="positive",
     )
+    near_port = Port(
+        center=(source_x + 0.45e-6, 0.0, 0.0),
+        size=plane_size,
+        name="near_mode",
+        direction="+",
+        mode_spec=source.mode_spec,
+    )
+    far_port = Port(
+        center=(source_x + 1.6e-6, 0.0, 0.0),
+        size=plane_size,
+        name="far_mode",
+        direction="+",
+        mode_spec=source.mode_spec,
+    )
     monitors = [
         negative_monitor,
         positive_monitor,
+        near_port.to_monitor([frequency]),
+        far_port.to_monitor([frequency]),
     ]
     simulation = Simulation(
         domain=domain,
@@ -91,7 +107,7 @@ def test_3d_mode_source_suppresses_counterpropagating_power_on_both_grids(
         sources=[source],
         monitors=monitors,
         boundaries=[PML(thickness=0.45e-6, formulation="cpml")],
-        run_time=6.0 / frequency,
+        run_time=20.0 / frequency,
     )
 
     program = simulation.compile()
@@ -130,6 +146,19 @@ def test_3d_mode_source_suppresses_counterpropagating_power_on_both_grids(
 
     assert forward_power > 0.0
     assert counter_power / forward_power < 0.05
+    if direction == "+":
+        waves = sp._extract_port_waves_dft(
+            result,
+            ports=[near_port, far_port],
+            frequencies=[frequency],
+            return_power=True,
+        )
+        near_modal_power = float(np.asarray(waves[near_port.name]["P_minus"])[0])
+        far_modal_power = float(np.asarray(waves[far_port.name]["P_minus"])[0])
+        assert far_modal_power == pytest.approx(near_modal_power, rel=0.02)
+        assert near_modal_power == pytest.approx(
+            abs(float(result[near_port.name].flux[0])), rel=0.02
+        )
 
 
 @pytest.mark.compiled

--- a/tests/unit/modes/test_yee.py
+++ b/tests/unit/modes/test_yee.py
@@ -2,6 +2,9 @@ import numpy as np
 import pytest
 
 from beamz.devices.modes._yee import (
+    _center_to_edge_difference,
+    _edge_to_center_difference,
+    _forward_difference,
     refine_x_mode_at_fixed_beta,
     validate_x_mode_refinement,
 )
@@ -43,6 +46,45 @@ def _refinement_fixture():
         "direction_sign": 1.0,
     }
     return shapes, profiles, indices, kwargs
+
+
+def test_rectilinear_difference_operators_preserve_uniform_limit():
+    from scipy import sparse
+
+    spacing = 0.3
+    widths = np.full(5, spacing)
+    forward = _forward_difference(sparse, widths.size, spacing)
+
+    np.testing.assert_allclose(
+        _center_to_edge_difference(sparse, widths).toarray(),
+        forward.toarray(),
+    )
+    np.testing.assert_allclose(
+        _edge_to_center_difference(sparse, widths).toarray(),
+        (-forward.T).toarray(),
+    )
+
+
+def test_rectilinear_difference_operators_use_primal_and_dual_spacings():
+    from scipy import sparse
+
+    widths = np.asarray([0.2, 0.3, 0.5])
+
+    np.testing.assert_allclose(
+        _center_to_edge_difference(sparse, widths).toarray(),
+        [
+            [-1.0 / 0.25, 1.0 / 0.25, 0.0],
+            [0.0, -1.0 / 0.4, 1.0 / 0.4],
+        ],
+    )
+    np.testing.assert_allclose(
+        _edge_to_center_difference(sparse, widths).toarray(),
+        [
+            [1.0 / 0.2, 0.0],
+            [-1.0 / 0.3, 1.0 / 0.3],
+            [0.0, -1.0 / 0.5],
+        ],
+    )
 
 
 def test_fixed_beta_refinement_returns_normalized_yee_shapes():


### PR DESCRIPTION
## Summary

Fix mode refinement and power normalization on nonuniform rectilinear grids. This was discovered while running the passive-device benchmarks in #230: a straight, lossless waveguide appeared to gain about 6.2% power after propagation.

### What was wrong

BeamZ stores electric and magnetic field components at different positions within each Yee cell. On a uniform grid, the derivative from cell centers to cell edges and the reverse derivative can both be derived from one constant spacing. The old refinement code relied on that relationship, so BeamZ disabled fixed-beta Yee refinement whenever cell sizes varied.

Without refinement, the mode profile used by sources and monitors was not fully consistent with the nonuniform grid used by FDTD. That mismatch showed up as changing modal power even in a straight waveguide.

### What changed

- Build center-to-edge derivatives from the distances between neighboring cell centers.
- Build edge-to-center derivatives from the widths of the cells containing those centers.
- Weight energy and power integrals by the physical area represented by each staggered field sample.
- Enable fixed-beta refinement for x-normal modes on rectilinear grids.
- Retain the existing validation and fallback path if a refined mode is not physically acceptable.

After the change, the straight-waveguide diagnostic changes from an apparent 6.2% increase to approximately 0.1% input/output disagreement. This PR is intentionally limited to the grid/mode fix; the device benchmarks remain separate in #230.

## Correctness

- uv run pytest -q tests/unit/modes/test_yee.py tests/integration/test_mode_source_integration.py
- Result after rebasing onto current main: 12 passed
- Tests cover the derivative operators, staggered integration weights, uniform-grid behavior, and mode-source propagation on both uniform and rectilinear grids.
- Ruff check and formatting checks pass for all changed files.
- Crossing diagnostics at 6, 10, and 15 cells per wavelength were also used during investigation; the 15-PPW through-power result agrees closely with the published reference.

## Ownership

Codex gpt-5.6-sol materially created and rewrote the Yee-grid implementation and its tests during an interactive investigation.